### PR TITLE
Support long running MCP session using token refesh

### DIFF
--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -8,10 +8,15 @@ const mockBringLogin = jest.fn();
 const mockBringLoadLists = jest.fn();
 
 jest.mock('bring-shopping', () => {
+  const token = JSON.stringify({
+    exp: Date.now() / 1000 + 20000,
+  });
+  const base64Url = Buffer.from(token).toString('base64');
   return jest.fn().mockImplementation(() => {
     return {
       login: mockBringLogin,
       loadLists: mockBringLoadLists,
+      bearerToken: `a.${base64Url}.a`,
       // Add other methods as needed by tests in this file or globally if preferred
     };
   });
@@ -122,10 +127,10 @@ describe('MCP Bring! Server - Tool Registration (Post-Login Refactor)', () => {
     const loginTool = getTool('login');
     expect(loginTool).toBeUndefined(); // The login tool should not be registered
     expect(mockMcpServerInstance.tool).not.toHaveBeenCalledWith(
-      'login',
-      expect.any(String),
-      expect.any(Object),
-      expect.any(Function),
+        'login',
+        expect.any(String),
+        expect.any(Object),
+        expect.any(Function),
     );
   });
 });

--- a/tests/bringClient.spec.ts
+++ b/tests/bringClient.spec.ts
@@ -8,6 +8,10 @@ const mockLoadTranslations = jest.fn();
 const mockLoadCatalog = jest.fn();
 
 jest.mock('bring-shopping', () => {
+  const token = JSON.stringify({
+    exp: Date.now() / 1000 + 20000,
+  });
+  const base64Url = Buffer.from(token).toString('base64');
   return jest.fn().mockImplementation(() => ({
     login: mockLogin,
     getItems: mockGetItems,
@@ -15,6 +19,7 @@ jest.mock('bring-shopping', () => {
     removeItem: mockRemoveItem,
     loadTranslations: mockLoadTranslations,
     loadCatalog: mockLoadCatalog,
+    bearerToken: `a.${base64Url}.a`,
   }));
 });
 


### PR DESCRIPTION
I'm using this MCP server in one of my agents. The agent is running always. As of now the Bring token expires after 7 days. I added a refresh based on the bearer token expiry.