### PR TITLE
Prevent incompatible TypeScript 7 Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
       all-dependencies:
         patterns:
           - '*'
+    ignore:
+      # TypeScript 7 is not yet supported by @typescript-eslint.
+      - dependency-name: 'typescript'
+        versions:
+          - '>=7.0.0'


### PR DESCRIPTION
## Summary

- ignore TypeScript versions `>=7.0.0` in Dependabot version updates
- continue allowing compatible TypeScript 6.x updates
- prevent the currently incompatible TypeScript 7 PR from being recreated after each dependency refresh

Dependabot PR #55 fails during `npm ci` because `@typescript-eslint/eslint-plugin@8.67.0` requires TypeScript `>=4.8.4 <6.1.0`, while #55 installs TypeScript 7.0.2.

The ignore can be removed once the ESLint/Jest TypeScript toolchain supports TypeScript 7.

## Verification

- Dependabot YAML parsed successfully
- `npm run test` — 66 tests passed
- `npm run build`

Addresses the recurring update from #55.