### PR TITLE
Fix npm release publishing and update Node.js support

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -18,13 +18,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x, 24.x, 26.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -5,9 +5,16 @@ name: 📦 Publish to npm
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to publish (for example, 1.1.8)
+        required: true
+        type: string
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -16,13 +23,16 @@ jobs:
 
     steps:
       - name: 🛎️ Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
 
       - name: 🧰 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24.x
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
 
       - name: 📦 Install dependencies
         run: npm ci
@@ -46,7 +56,7 @@ jobs:
 
       - name: 🔢 Set package.json version from tag
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
           if [[ ! "$RELEASE_TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-beta(\.[0-9]+)?)?$ ]]; then
             echo "Invalid release tag"
@@ -58,8 +68,7 @@ jobs:
 
       - name: 🚀 Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
           echo "Publishing version: $RELEASE_TAG"
           TAG="latest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "bring-mcp",
       "version": "0.9.2-beta",
       "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "bring-shopping": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,13 @@
   "author": "florianwittkamp",
   "license": "MIT",
   "description": "MCP Server for Bring! Shopping",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/florianwittkamp/bring-mcp.git"
+  },
+  "engines": {
+    "node": ">=22"
+  },
   "files": [
     "build/**/*",
     "README.md",


### PR DESCRIPTION
## Summary

- update CI coverage from EOL Node.js 18/20 to Node.js 22, 24, and 26
- update `actions/checkout` and `actions/setup-node` to v6
- migrate npm publishing from a long-lived token to trusted publishing via OIDC
- add a manual retry input so the existing `1.1.8` tag can be published without recreating the release
- declare Node.js 22+ support and add the repository metadata required by npm trusted publishing

## Verification

- `npm run test` — 7 suites, 66 tests passed
- `npm run build` — passed
- `npm pack --dry-run` — passed
- `git diff --check` — passed

## Required npm configuration

Before publishing, configure the package's npm Trusted Publisher with:

- GitHub user: `florianwittkamp`
- Repository: `bring-mcp`
- Workflow: `publish-npm.yml`
- Allowed action: `npm publish`

After merging, run the **Publish to npm** workflow manually with `release_tag = 1.1.8` to retry the failed release.