### PR TITLE
Fix npm metadata for release retries

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -66,6 +66,14 @@ jobs:
           echo "Setting package.json version to $VERSION"
           npm version "$VERSION" --no-git-tag-version
 
+      - name: Normalize package metadata
+        run: |
+          npm pkg set \
+            "repository.type=git" \
+            "repository.url=git+https://github.com/${GITHUB_REPOSITORY}.git" \
+            "bin.bring-mcp=build/src/index.js"
+          npm pkg fix
+
       - name: 🚀 Publish to npm
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "LICENSE"
   ],
   "bin": {
-    "bring-mcp": "./build/src/index.js"
+    "bring-mcp": "build/src/index.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

- normalize package metadata after checking out an existing release tag
- restore the exact GitHub repository URL required by npm Trusted Publishing
- normalize the CLI `bin` path for npm 11

This keeps the source code from tag `1.1.8` while adding the publishing metadata that did not exist in that tag.

## Verification

- `npm run test` — 7 suites, 66 tests passed
- `npm run build` — passed
- simulated the complete metadata/version preparation from tag `1.1.8`
- `npm pack --dry-run` for the prepared `1.1.8` package — passed without the invalid-bin warning

After merging, run **Publish to npm** manually again with `release_tag = 1.1.8`.