### PR TITLE
Fall back to sole list when defaultListUUID is unset

### DIFF
--- a/src/tools/userTools.ts
+++ b/src/tools/userTools.ts
@@ -59,7 +59,14 @@ export function registerUserTools(server: McpServer, bc: BringClient) {
           return defaultListSetting.value;
         }
       }
-      throw new Error('Default list UUID not found in user settings.');
+
+      const listsResponse = await bc.loadLists();
+      const lists = listsResponse?.lists;
+      if (Array.isArray(lists) && lists.length === 1 && lists[0]?.listUuid) {
+        return lists[0].listUuid;
+      }
+
+      return 'No default list is configured. Set one in the Bring app, or call loadLists to choose.';
     },
     failureMessage: 'Failed to get default list UUID',
     transformResult: (result: string) => ({

--- a/tests/users.spec.ts
+++ b/tests/users.spec.ts
@@ -2,6 +2,7 @@ import {
   mockGetAllUsersFromList,
   mockGetUserSettings,
   mockGetPendingInvitations,
+  mockLoadLists,
   mockMcpServerInstance,
   mockTools,
   loadServer,
@@ -190,6 +191,7 @@ describe('MCP Bring! Server - User Tools', () => {
         ],
       };
       mockGetUserSettings.mockResolvedValue(fakeSettingsWithoutUuid);
+      mockLoadLists.mockResolvedValue({ lists: [] });
       const tool = getTool('getDefaultList');
       if (!tool) throw new Error('Tool getDefaultList not found');
 
@@ -197,7 +199,10 @@ describe('MCP Bring! Server - User Tools', () => {
       expect(mockGetUserSettings).toHaveBeenCalledTimes(1);
       expect(result).toEqual({
         content: [
-          { type: 'text', text: 'Failed to get default list UUID: Default list UUID not found in user settings.' },
+          {
+            type: 'text',
+            text: 'No default list is configured. Set one in the Bring app, or call loadLists to choose.',
+          },
         ],
       });
     });
@@ -218,6 +223,7 @@ describe('MCP Bring! Server - User Tools', () => {
     it('should return error if usersettings structure is invalid', async () => {
       const fakeSettingsInvalidStructure = { someOtherProperty: 'value' }; // Missing usersettings array
       mockGetUserSettings.mockResolvedValue(fakeSettingsInvalidStructure);
+      mockLoadLists.mockResolvedValue({ lists: [] });
       const tool = getTool('getDefaultList');
       if (!tool) throw new Error('Tool getDefaultList not found');
 
@@ -225,9 +231,67 @@ describe('MCP Bring! Server - User Tools', () => {
       expect(mockGetUserSettings).toHaveBeenCalledTimes(1);
       expect(result).toEqual({
         content: [
-          { type: 'text', text: 'Failed to get default list UUID: Default list UUID not found in user settings.' },
+          {
+            type: 'text',
+            text: 'No default list is configured. Set one in the Bring app, or call loadLists to choose.',
+          },
         ],
       });
+    });
+
+    it('should fall back to the sole list UUID when defaultListUUID is unset', async () => {
+      const soleListUuid = 'casa-list-uuid-456';
+      mockGetUserSettings.mockResolvedValue({
+        usersettings: [
+          { key: 'autoPush', value: 'true' },
+          { key: 'onboardClient', value: 'web' },
+        ],
+      });
+      mockLoadLists.mockResolvedValue({
+        lists: [{ listUuid: soleListUuid, name: 'Casa' }],
+      });
+      const tool = getTool('getDefaultList');
+      if (!tool) throw new Error('Tool getDefaultList not found');
+
+      const result = await tool.callback({});
+      expect(mockGetUserSettings).toHaveBeenCalledTimes(1);
+      expect(mockLoadLists).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({
+        content: [{ type: 'text', text: soleListUuid }],
+      });
+    });
+
+    it('should return guidance when defaultListUUID is unset and multiple lists exist', async () => {
+      mockGetUserSettings.mockResolvedValue({
+        usersettings: [{ key: 'autoPush', value: 'true' }],
+      });
+      mockLoadLists.mockResolvedValue({
+        lists: [
+          { listUuid: 'uuid-a', name: 'Casa' },
+          { listUuid: 'uuid-b', name: 'Work' },
+        ],
+      });
+      const tool = getTool('getDefaultList');
+      if (!tool) throw new Error('Tool getDefaultList not found');
+
+      const result = await tool.callback({});
+      expect(mockLoadLists).toHaveBeenCalledTimes(1);
+      expect(result.content[0].text).toMatch(/loadLists/i);
+      expect(result.content[0].text).not.toMatch(/Failed to get default list UUID/i);
+    });
+
+    it('should return guidance when defaultListUUID is unset and no lists exist', async () => {
+      mockGetUserSettings.mockResolvedValue({
+        usersettings: [{ key: 'autoPush', value: 'true' }],
+      });
+      mockLoadLists.mockResolvedValue({ lists: [] });
+      const tool = getTool('getDefaultList');
+      if (!tool) throw new Error('Tool getDefaultList not found');
+
+      const result = await tool.callback({});
+      expect(mockLoadLists).toHaveBeenCalledTimes(1);
+      expect(result.content[0].text).toMatch(/loadLists/i);
+      expect(result.content[0].text).not.toMatch(/Failed to get default list UUID/i);
     });
   });
 });


### PR DESCRIPTION
When Bring user settings omit `defaultListUUID` (common on single-list accounts that never set a default in the app), `getDefaultList` threw `Default list UUID not found in user settings.` even though `loadLists` returned a single unambiguous list.

If the key is missing, call `loadLists` and return that list's UUID when there is exactly one list. Otherwise return a non-throwing message telling the agent to call `loadLists` or set a default in Bring.

Credit @SpellsPT. Fixes #59.