### PR TITLE
fix: escape the legacy list-mutation body instead of concatenating it

### DIFF
--- a/src/bringClient.ts
+++ b/src/bringClient.ts
@@ -70,17 +70,58 @@ export class BringClient {
     await this.ensureLoggedIn();
     return this.bring.getItemsDetails(listUuid);
   }
-  async saveItem(listUuid: string, itemName: string, specification: string | null | undefined) {
+  /**
+   * The legacy list-mutation endpoint, sent with correct form encoding.
+   *
+   * `bring-shopping` builds this body by string concatenation with no escaping
+   * (`&purchase=${itemName}&recently=&specification=${specification}&...`), so
+   * any `&`, `+` or `%` in a name corrupts the request - silently, because it
+   * also never checks the response status:
+   *
+   *   "Fish & Chips"  -> stored as "Fish"          (truncated at the &)
+   *   "Salt + Pepper" -> stored as "Salt   Pepper" (+ decoded as a space)
+   *   "50% Cream"     -> never arrives at all      (invalid escape sequence)
+   *
+   * Going through URLSearchParams fixes both problems at once: values are
+   * escaped, and a non-2xx now throws instead of being returned as an ordinary
+   * string. Returns the raw body (empty on the usual 204) so callers see
+   * exactly what the library used to give them.
+   */
+  private async legacyListMutation(listUuid: string, fields: Record<string, string>): Promise<string> {
     await this.ensureLoggedIn();
-    return this.bring.saveItem(listUuid, itemName, specification || '');
+    const headers = this.bring['headers'] as Record<string, string>;
+    const body = new URLSearchParams({
+      purchase: '',
+      recently: '',
+      specification: '',
+      remove: '',
+      sender: 'null',
+      ...fields,
+    }).toString();
+
+    const res = await fetch(`https://api.getbring.com/rest/v2/bringlists/${listUuid}`, {
+      method: 'PUT',
+      headers: {
+        ...headers,
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+      },
+      body,
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      throw new Error(`Bring! API PUT /v2/bringlists/${listUuid} failed (${res.status}): ${text.slice(0, 300)}`);
+    }
+    return text;
+  }
+
+  async saveItem(listUuid: string, itemName: string, specification: string | null | undefined) {
+    return this.legacyListMutation(listUuid, { purchase: itemName, specification: specification || '' });
   }
   async removeItem(listUuid: string, itemId: string) {
-    await this.ensureLoggedIn();
-    return this.bring.removeItem(listUuid, itemId);
+    return this.legacyListMutation(listUuid, { remove: itemId });
   }
   async moveToRecentList(listUuid: string, itemId: string) {
-    await this.ensureLoggedIn();
-    return this.bring.moveToRecentList(listUuid, itemId);
+    return this.legacyListMutation(listUuid, { recently: itemId });
   }
 
   /**
@@ -129,7 +170,7 @@ export class BringClient {
     await this.ensureLoggedIn();
     const results = [];
     for (const item of items) {
-      const result = await this.bring.saveItem(listUuid, item.itemName, item.specification || '');
+      const result = await this.saveItem(listUuid, item.itemName, item.specification || '');
       results.push(result);
     }
     return results;

--- a/src/bringClient.ts
+++ b/src/bringClient.ts
@@ -182,7 +182,7 @@ export class BringClient {
     for (const itemName of itemNames) {
       // Assuming itemId is the same as itemName for removal,
       // consistent with how getItems structures it and how removeItem is likely used.
-      const result = await this.bring.removeItem(listUuid, itemName);
+      const result = await this.removeItem(listUuid, itemName);
       results.push(result);
     }
     return results;

--- a/tests/bringClient.spec.ts
+++ b/tests/bringClient.spec.ts
@@ -27,11 +27,22 @@ jest.mock('bring-shopping', () => {
   }));
 });
 
+let sentBodies: string[] = [];
+
 describe('BringClient functionality', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.MAIL = 'test@example.com';
     process.env.PW = 'pw';
+    // saveItem/removeItem/moveToRecentList now build their own escaped form
+    // body instead of delegating to bring-shopping, so the suite has to stub
+    // fetch. Without this these tests reach api.getbring.com for real and fail
+    // with a 401.
+    sentBodies = [];
+    global.fetch = jest.fn().mockImplementation((_url: string, init: { body?: string }) => {
+      sentBodies.push(String(init?.body ?? ''));
+      return Promise.resolve({ ok: true, status: 204, text: () => Promise.resolve('') });
+    }) as unknown as typeof fetch;
   });
 
   test('getItems adds itemId to purchase and recently items', async () => {
@@ -51,24 +62,28 @@ describe('BringClient functionality', () => {
   });
 
   test('saveItem forwards empty specification string when undefined', async () => {
-    mockSaveItem.mockResolvedValue({ ok: true });
     const bc = new BringClient();
 
     await bc.saveItem('listA', 'Eggs', undefined);
 
     expect(mockLogin).toHaveBeenCalledTimes(1);
-    expect(mockSaveItem).toHaveBeenCalledWith('listA', 'Eggs', '');
+    const body = new URLSearchParams(sentBodies[0]);
+    expect(body.get('purchase')).toBe('Eggs');
+    expect(body.get('specification')).toBe('');
   });
 
   test('saveItemBatch saves each item individually', async () => {
-    mockSaveItem.mockResolvedValueOnce('r1').mockResolvedValueOnce('r2');
     const bc = new BringClient();
 
-    const result = await bc.saveItemBatch('listB', [{ itemName: 'A', specification: '1' }, { itemName: 'B' }]);
+    await bc.saveItemBatch('listB', [{ itemName: 'A', specification: '1' }, { itemName: 'B' }]);
 
-    expect(mockSaveItem).toHaveBeenNthCalledWith(1, 'listB', 'A', '1');
-    expect(mockSaveItem).toHaveBeenNthCalledWith(2, 'listB', 'B', '');
-    expect(result).toEqual(['r1', 'r2']);
+    expect(sentBodies).toHaveLength(2);
+    const first = new URLSearchParams(sentBodies[0]);
+    const second = new URLSearchParams(sentBodies[1]);
+    expect(first.get('purchase')).toBe('A');
+    expect(first.get('specification')).toBe('1');
+    expect(second.get('purchase')).toBe('B');
+    expect(second.get('specification')).toBe('');
   });
 
   test('deleteMultipleItemsFromList removes each item', async () => {

--- a/tests/bringClient.spec.ts
+++ b/tests/bringClient.spec.ts
@@ -87,14 +87,13 @@ describe('BringClient functionality', () => {
   });
 
   test('deleteMultipleItemsFromList removes each item', async () => {
-    mockRemoveItem.mockResolvedValueOnce('ok1').mockResolvedValueOnce('ok2');
     const bc = new BringClient();
 
-    const result = await bc.deleteMultipleItemsFromList('listC', ['x', 'y']);
+    await bc.deleteMultipleItemsFromList('listC', ['x', 'y']);
 
-    expect(mockRemoveItem).toHaveBeenNthCalledWith(1, 'listC', 'x');
-    expect(mockRemoveItem).toHaveBeenNthCalledWith(2, 'listC', 'y');
-    expect(result).toEqual(['ok1', 'ok2']);
+    expect(sentBodies).toHaveLength(2);
+    expect(new URLSearchParams(sentBodies[0]).get('remove')).toBe('x');
+    expect(new URLSearchParams(sentBodies[1]).get('remove')).toBe('y');
   });
 
   test('loadTranslations defaults to en-US when no locale is provided', async () => {

--- a/tests/escaping.spec.ts
+++ b/tests/escaping.spec.ts
@@ -67,6 +67,12 @@ describe('legacy list mutation encoding', () => {
     expect(bodyOf(1).get('recently')).toBe('Salt + Pepper');
   });
 
+  test('escapes names when removing multiple items', async () => {
+    await new BringClient().deleteMultipleItemsFromList(LIST, ['Fish & Chips', 'Salt + Pepper']);
+    expect(bodyOf(0).get('remove')).toBe('Fish & Chips');
+    expect(bodyOf(1).get('remove')).toBe('Salt + Pepper');
+  });
+
   test('throws instead of silently reporting success on a non-2xx', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,

--- a/tests/escaping.spec.ts
+++ b/tests/escaping.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * The legacy list-mutation endpoint takes a form body. `bring-shopping` builds
+ * that body by string concatenation with no escaping, so a name containing
+ * `&`, `+` or `%` corrupts the request - and because the library also never
+ * checks the response status, the corruption is silent.
+ *
+ * These drive the real BringClient with `fetch` stubbed, and assert on the
+ * bytes that actually go out.
+ */
+import { BringClient } from '../src/bringClient';
+
+const mockLogin = jest.fn();
+
+jest.mock('bring-shopping', () => {
+  const token = JSON.stringify({ exp: Date.now() / 1000 + 20000 });
+  const base64Url = Buffer.from(token).toString('base64');
+  return jest.fn().mockImplementation(() => ({
+    login: mockLogin,
+    bearerToken: `a.${base64Url}.a`,
+    headers: { Authorization: 'Bearer test', 'X-BRING-USER-UUID': 'user-uuid' },
+  }));
+});
+
+const LIST = '11111111-2222-4333-8444-555555555555';
+let sent: { url: string; body: string }[] = [];
+
+describe('legacy list mutation encoding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.MAIL = 'test@example.com';
+    process.env.PW = 'pw';
+    sent = [];
+    global.fetch = jest.fn().mockImplementation((url: string, init: { body?: string }) => {
+      sent.push({ url: String(url), body: String(init?.body ?? '') });
+      return Promise.resolve({ ok: true, status: 204, text: () => Promise.resolve('') });
+    }) as unknown as typeof fetch;
+  });
+
+  const bodyOf = (i: number) => new URLSearchParams(sent[i].body);
+
+  test('does not truncate a name containing an ampersand', async () => {
+    await new BringClient().saveItem(LIST, 'Fish & Chips', '');
+    // Concatenation sent `purchase=Fish & Chips`, so the server stored "Fish".
+    expect(bodyOf(0).get('purchase')).toBe('Fish & Chips');
+  });
+
+  test('does not turn a plus into a space', async () => {
+    await new BringClient().saveItem(LIST, 'Salt + Pepper', '');
+    expect(bodyOf(0).get('purchase')).toBe('Salt + Pepper');
+  });
+
+  test('survives a percent sign', async () => {
+    await new BringClient().saveItem(LIST, '50% Cream', '');
+    expect(bodyOf(0).get('purchase')).toBe('50% Cream');
+  });
+
+  test('escapes the specification too', async () => {
+    await new BringClient().saveItem(LIST, 'Milk', '1 & 1/2 L');
+    expect(bodyOf(0).get('specification')).toBe('1 & 1/2 L');
+  });
+
+  test('escapes names on the remove and recently paths', async () => {
+    const bc = new BringClient();
+    await bc.removeItem(LIST, 'Fish & Chips');
+    await bc.moveToRecentList(LIST, 'Salt + Pepper');
+    expect(bodyOf(0).get('remove')).toBe('Fish & Chips');
+    expect(bodyOf(1).get('recently')).toBe('Salt + Pepper');
+  });
+
+  test('throws instead of silently reporting success on a non-2xx', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('Internal Server Error'),
+    }) as unknown as typeof fetch;
+    await expect(new BringClient().saveItem(LIST, 'Milk', '')).rejects.toThrow(/failed \(500\)/);
+  });
+});


### PR DESCRIPTION
Item names containing `&`, `+` or `%` are silently corrupted on save, remove and mark-bought.

## The bug

`bring-shopping` builds the body for `PUT /v2/bringlists/{uuid}` by string concatenation, with no escaping:

```js
body: `&purchase=${itemName}&recently=&specification=${specification}&remove=&sender=null`
```

Because it also never checks the response status, the corruption is completely silent — the tool reports success:

| you add | Bring stores |
|---|---|
| `Fish & Chips` | **`Fish`** (truncated at the `&`) |
| `Salt + Pepper` | `Salt   Pepper` (`+` decoded as a space) |
| `50% Cream` | **nothing** (invalid escape sequence) |

`&` is common in real shopping lists, and on a shared list a wrong item is visible to everyone on it.

## The change

`saveItem`, `removeItem` and `moveToRecentList` build the form body with `URLSearchParams` and throw on a non-2xx, instead of delegating to the library. `saveItemBatch` and `deleteMultipleItemsFromList` pick it up by going through the corresponding single-item methods.

The remaining methods still delegate to `bring-shopping` exactly as before. This keeps the change scoped to calls that hit the legacy form endpoint.

## Tests

`tests/escaping.spec.ts` covers the ampersand, plus and percent cases, the `specification` field, the single and batch `remove` paths, the `recently` path, and the non-2xx throw. **All seven fail against the original code and pass with this change.**

## One thing worth flagging

Two existing tests in `bringClient.spec.ts` asserted that the *library method* had been called, which is no longer how these paths work, so they now assert on the request body actually produced.

While making that change I noticed something you may want to know independently of this PR: because those tests only ever mocked `bring-shopping`, nothing in the suite exercised the wire format — and once these methods used `fetch` directly, the tests reached `api.getbring.com` for real and failed with a 401. I have stubbed `fetch` in that file’s `beforeEach` so the suite cannot escape to the network, but there is no global guard against that elsewhere.

Full suite: 73 passing, `prettier --check` and `eslint` clean.

---

Happy to split this, drop the test-file changes, or adjust the style to taste — I appreciate this is an unsolicited PR against your project. Thanks for building it; it is the basis of a fork I use daily.