### PR TITLE
Modernize MCP tool responses and credential names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-MAIL=your_email@example.com
-PW=your_password
+BRING_EMAIL=your_email@example.com
+BRING_PASSWORD=your_password

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ To use this server in Claude Desktop via `npx`, insert the following into your `
       "command": "npx",
       "args": ["-y", "bring-mcp@latest"],
       "env": {
-        "MAIL": "your_bring_email@example.com",
-        "PW": "YOUR_BRING_PASSWORD_HERE"
+        "BRING_EMAIL": "your_bring_email@example.com",
+        "BRING_PASSWORD": "YOUR_BRING_PASSWORD_HERE"
       }
     }
   }
@@ -91,8 +91,8 @@ This is the recommended and most portable configuration. It ensures you always u
 4. **Create `.env` file (if not injecting ENV directly):**
 
    ```env
-   MAIL=your_email@example.com
-   PW=your_password
+   BRING_EMAIL=your_email@example.com
+   BRING_PASSWORD=your_password
    ```
 
 5. **Build the project:**
@@ -144,8 +144,8 @@ Alternatively, if you prefer a locally built and installed version:
       "command": "node",
       "args": ["/ABSOLUTE/PATH/TO/bring-mcp/build/src/index.js"],
       "env": {
-        "MAIL": "your_bring_email@example.com",
-        "PW": "YOUR_BRING_PASSWORD_HERE"
+        "BRING_EMAIL": "your_bring_email@example.com",
+        "BRING_PASSWORD": "YOUR_BRING_PASSWORD_HERE"
       }
     }
   }
@@ -193,6 +193,7 @@ npm run build
 ## ✅ Final Notes
 
 - 🔒 Avoid committing your `.env` file.
+- ♻️ `MAIL` and `PW` remain supported as deprecated aliases for existing installations.
 - 🧼 Keep credentials out of version control.
 - 🛠 MCP Inspector is invaluable for debugging.
 - 🔄 Authentication is handled automatically - no manual login required.

--- a/src/bringClient.ts
+++ b/src/bringClient.ts
@@ -1,9 +1,19 @@
 import Bring from 'bring-shopping';
 
 export class BringClient {
-  private bring = new Bring({ mail: process.env.MAIL!, password: process.env.PW! });
+  private bring: Bring;
   private isLoggedIn = false;
   private tokenExpiresAt: Date | undefined;
+
+  constructor(
+    email = process.env.BRING_EMAIL ?? process.env.MAIL,
+    password = process.env.BRING_PASSWORD ?? process.env.PW,
+  ) {
+    if (!email || !password) {
+      throw new Error('Missing BRING_EMAIL or BRING_PASSWORD environment variables.');
+    }
+    this.bring = new Bring({ mail: email, password });
+  }
 
   private async _login() {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { z, ZodRawShape, ZodObject } from 'zod';
 import { BringClient } from './bringClient.js';
 import 'dotenv/config';
@@ -29,9 +30,17 @@ function textToolResult(text: string) {
 
 // Helper function to create a JSON response (as stringified text)
 function jsonToolResult(data: unknown) {
-  const contentPart: McpContentPart = { type: 'text', text: JSON.stringify(data, null, 2) };
+  const contentPart: McpContentPart = { type: 'text', text: JSON.stringify(data, null, 2) ?? 'null' };
   return { content: [contentPart] };
 }
+
+function structuredToolResult(data: unknown) {
+  return { result: data === undefined ? null : data };
+}
+
+const outputSchema = {
+  result: z.unknown().describe('The structured result returned by the Bring! API operation.'),
+};
 
 // Generic tool registration helper - Overloads
 export function registerTool<TParams extends ZodRawShape, TResult, TArgs = z.infer<ZodObject<TParams>>>(options: {
@@ -43,6 +52,7 @@ export function registerTool<TParams extends ZodRawShape, TResult, TArgs = z.inf
   actionFn: (args: TArgs, bc: BringClient) => Promise<TResult>;
   transformResult?: (result: TResult) => { content: McpContentPart[] };
   failureMessage: string;
+  annotations: ToolAnnotations;
 }): void;
 export function registerTool<TResult>(options: {
   server: McpServer;
@@ -53,6 +63,7 @@ export function registerTool<TResult>(options: {
   actionFn: (args: undefined, bc: BringClient) => Promise<TResult>; // Args are undefined
   transformResult?: (result: TResult) => { content: McpContentPart[] };
   failureMessage: string;
+  annotations: ToolAnnotations;
 }): void;
 // Implementation signature for registerTool
 export function registerTool(options: {
@@ -66,44 +77,69 @@ export function registerTool(options: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   transformResult?: (result: any) => { content: McpContentPart[] };
   failureMessage: string;
+  annotations: ToolAnnotations;
 }) {
-  const { server, bc, name, description, schemaShape, actionFn, transformResult, failureMessage } = options;
+  const { server, bc, name, description, schemaShape, actionFn, transformResult, failureMessage, annotations } =
+    options;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const callback = async (args: any) => {
     try {
       const res = await actionFn(args, bc);
       if (transformResult) {
-        return transformResult(res);
+        return {
+          ...transformResult(res),
+          structuredContent: structuredToolResult(res),
+        };
       }
-      return jsonToolResult(res);
+      return {
+        ...jsonToolResult(res),
+        structuredContent: structuredToolResult(res),
+      };
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error(`${failureMessage}:`, error);
-      return textToolResult(`${failureMessage}: ${errorMessage}`);
+      return {
+        ...textToolResult(`${failureMessage}: ${errorMessage}`),
+        isError: true,
+      };
     }
   };
 
-  if (schemaShape) {
-    server.tool(name, description, schemaShape, callback);
-  } else {
-    server.tool(name, description, {}, callback);
-  }
+  server.registerTool(
+    name,
+    {
+      description,
+      inputSchema: schemaShape ?? {},
+      outputSchema,
+      annotations,
+    },
+    callback,
+  );
 }
 
 // Register login tool and other tools moved into main
 
 // Start the server
 async function main() {
-  if (!process.env.MAIL || !process.env.PW) {
+  const email = process.env.BRING_EMAIL ?? process.env.MAIL;
+  const password = process.env.BRING_PASSWORD ?? process.env.PW;
+
+  if (!email || !password) {
     console.error(
-      'Missing MAIL or PW environment variables. Please create a .env file with your Bring credentials (e.g., MAIL=your_email@example.com\nPW=your_password).',
+      'Missing BRING_EMAIL or BRING_PASSWORD environment variables. Please provide your Bring! credentials through the environment or a .env file.',
     );
     process.exit(1);
     return;
   }
 
-  const bc = new BringClient(); // Instantiated after env check
+  if (!process.env.BRING_EMAIL || !process.env.BRING_PASSWORD) {
+    console.error(
+      'Deprecation warning: MAIL and PW are legacy aliases. Please migrate to BRING_EMAIL and BRING_PASSWORD.',
+    );
+  }
+
+  const bc = new BringClient(email, password); // Instantiated after env check
 
   // Register tools from modules
   registerListTools(server, bc);

--- a/src/toolAnnotations.ts
+++ b/src/toolAnnotations.ts
@@ -1,0 +1,15 @@
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+
+export const READ_ONLY_TOOL_ANNOTATIONS = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: true,
+} satisfies ToolAnnotations;
+
+export const MUTATING_TOOL_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: false,
+  openWorldHint: true,
+} satisfies ToolAnnotations;

--- a/src/tools/catalogTools.ts
+++ b/src/tools/catalogTools.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { BringClient } from '../bringClient.js';
 import { registerTool } from '../index.js';
+import { READ_ONLY_TOOL_ANNOTATIONS } from '../toolAnnotations.js';
 
 export function registerCatalogTools(server: McpServer, bc: BringClient) {
   const loadTranslationsParams = z.object({
@@ -19,6 +20,7 @@ export function registerCatalogTools(server: McpServer, bc: BringClient) {
     schemaShape: loadTranslationsParams.shape,
     actionFn: async (args: z.infer<typeof loadTranslationsParams>, bc: BringClient) => bc.loadTranslations(args.locale),
     failureMessage: 'Failed to load translations',
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
 
   const loadCatalogParams = z.object({
@@ -32,5 +34,6 @@ export function registerCatalogTools(server: McpServer, bc: BringClient) {
     schemaShape: loadCatalogParams.shape,
     actionFn: async (args: z.infer<typeof loadCatalogParams>, bc: BringClient) => bc.loadCatalog(args.locale),
     failureMessage: 'Failed to load catalog',
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
 }

--- a/src/tools/itemTools.ts
+++ b/src/tools/itemTools.ts
@@ -11,6 +11,7 @@ import {
   saveItemBatchParams,
   itemNamesArrayParam,
 } from '../schemaShared.js';
+import { MUTATING_TOOL_ANNOTATIONS, READ_ONLY_TOOL_ANNOTATIONS } from '../toolAnnotations.js';
 
 export function registerItemTools(server: McpServer, bc: BringClient) {
   const getItemsParams = z.object({
@@ -24,6 +25,7 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     schemaShape: getItemsParams.shape,
     actionFn: async (args: z.infer<typeof getItemsParams>, bc: BringClient) => bc.getItems(args.listUuid),
     failureMessage: 'Failed to get items',
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
 
   const getItemsDetailsParams = z.object({
@@ -37,6 +39,7 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     schemaShape: getItemsDetailsParams.shape,
     actionFn: async (args: z.infer<typeof getItemsDetailsParams>, bc: BringClient) => bc.getItemsDetails(args.listUuid),
     failureMessage: 'Failed to get item details',
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
 
   registerTool({
@@ -53,6 +56,7 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
       content: [{ type: 'text', text: `Item saved: ${JSON.stringify(result)}` }],
     }),
     failureMessage: 'Failed to save item',
+    annotations: MUTATING_TOOL_ANNOTATIONS,
   });
 
   registerTool({
@@ -69,6 +73,7 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
       content: [{ type: 'text', text: `Batch items saved: ${JSON.stringify(result)}` }],
     }),
     failureMessage: 'Failed to save batch items',
+    annotations: MUTATING_TOOL_ANNOTATIONS,
   });
 
   const removeItemParams = z.object({
@@ -84,6 +89,7 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     actionFn: async (args: z.infer<typeof removeItemParams>, bc: BringClient) =>
       bc.removeItem(args.listUuid, args.itemId),
     failureMessage: 'Failed to remove item',
+    annotations: MUTATING_TOOL_ANNOTATIONS,
   });
 
   const moveToRecentListParams = z.object({
@@ -99,6 +105,7 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     actionFn: async (args: z.infer<typeof moveToRecentListParams>, bc: BringClient) =>
       bc.moveToRecentList(args.listUuid, args.itemId),
     failureMessage: 'Failed to move item to recent list',
+    annotations: MUTATING_TOOL_ANNOTATIONS,
   });
 
   const saveItemImageParams = z.object({
@@ -114,6 +121,7 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     actionFn: async (args: z.infer<typeof saveItemImageParams>, bc: BringClient) =>
       bc.saveItemImage(args.itemId, args.imageData),
     failureMessage: 'Failed to save item image',
+    annotations: MUTATING_TOOL_ANNOTATIONS,
   });
 
   const removeItemImageParams = z.object({
@@ -127,6 +135,7 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     schemaShape: removeItemImageParams.shape,
     actionFn: async (args: z.infer<typeof removeItemImageParams>, bc: BringClient) => bc.removeItemImage(args.itemId),
     failureMessage: 'Failed to remove item image',
+    annotations: MUTATING_TOOL_ANNOTATIONS,
   });
 
   const deleteMultipleItemsParams = z.object({
@@ -145,5 +154,6 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
       content: [{ type: 'text', text: `Multiple items deleted: ${JSON.stringify(result)}` }],
     }),
     failureMessage: 'Failed to delete multiple items',
+    annotations: MUTATING_TOOL_ANNOTATIONS,
   });
 }

--- a/src/tools/listTools.ts
+++ b/src/tools/listTools.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 // import { z } from 'zod'; // Removed as z is unused
 import { BringClient } from '../bringClient.js';
 import { registerTool } from '../index.js'; // Assuming registerTool will be exported from index.ts
+import { READ_ONLY_TOOL_ANNOTATIONS } from '../toolAnnotations.js';
 
 export function registerListTools(server: McpServer, bc: BringClient) {
   registerTool({
@@ -12,6 +13,7 @@ export function registerListTools(server: McpServer, bc: BringClient) {
     schemaShape: undefined, // Explicitly undefined for no-args tool
     actionFn: async (_args: undefined, bc: BringClient) => bc.loadLists(),
     failureMessage: 'Failed to load lists',
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
 
   // Add other list-related tools here if any in the future

--- a/src/tools/userTools.ts
+++ b/src/tools/userTools.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { BringClient } from '../bringClient.js';
 import { registerTool } from '../index.js';
 import { listUuidParam } from '../schemaShared.js';
+import { READ_ONLY_TOOL_ANNOTATIONS } from '../toolAnnotations.js';
 
 export function registerUserTools(server: McpServer, bc: BringClient) {
   const getAllUsersFromListParams = z.object({
@@ -17,6 +18,7 @@ export function registerUserTools(server: McpServer, bc: BringClient) {
     actionFn: async (args: z.infer<typeof getAllUsersFromListParams>, bc: BringClient) =>
       bc.getAllUsersFromList(args.listUuid),
     failureMessage: 'Failed to get all users from list',
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
 
   registerTool({
@@ -27,6 +29,7 @@ export function registerUserTools(server: McpServer, bc: BringClient) {
     schemaShape: undefined,
     actionFn: async (_args: undefined, bc: BringClient) => bc.getUserSettings(),
     failureMessage: 'Failed to get user settings',
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
 
   registerTool({
@@ -37,6 +40,7 @@ export function registerUserTools(server: McpServer, bc: BringClient) {
     schemaShape: undefined,
     actionFn: async (_args: undefined, bc: BringClient) => bc.getPendingInvitations(),
     failureMessage: 'Failed to get pending invitations',
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
 
   registerTool({
@@ -72,5 +76,6 @@ export function registerUserTools(server: McpServer, bc: BringClient) {
     transformResult: (result: string) => ({
       content: [{ type: 'text', text: result }],
     }),
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
 }

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -6,18 +6,19 @@ let consoleErrorSpy: jest.SpyInstance;
 // Mock the Bring library
 const mockBringLogin = jest.fn();
 const mockBringLoadLists = jest.fn();
+const mockBringOptions: { mail: string; password: string }[] = [];
 
 jest.mock('bring-shopping', () => {
-  const token = JSON.stringify({
-    exp: Date.now() / 1000 + 20000,
-  });
-  const base64Url = Buffer.from(token).toString('base64');
-  return jest.fn().mockImplementation(() => {
+  return jest.fn().mockImplementation((options: { mail: string; password: string }) => {
+    mockBringOptions.push(options);
+    const token = JSON.stringify({
+      exp: Date.now() / 1000 + 20000,
+    });
+    const base64Url = Buffer.from(token).toString('base64');
     return {
       login: mockBringLogin,
       loadLists: mockBringLoadLists,
       bearerToken: `a.${base64Url}.a`,
-      // Add other methods as needed by tests in this file or globally if preferred
     };
   });
 });
@@ -26,7 +27,10 @@ describe('BringClient Automatic Login', () => {
   beforeEach(() => {
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     jest.clearAllMocks();
+    mockBringOptions.length = 0;
     // Reset environment variables for each test to ensure isolation
+    delete process.env.BRING_EMAIL;
+    delete process.env.BRING_PASSWORD;
     delete process.env.MAIL;
     delete process.env.PW;
   });
@@ -36,8 +40,8 @@ describe('BringClient Automatic Login', () => {
   });
 
   it('should automatically login on the first API call and succeed if credentials are valid', async () => {
-    process.env.MAIL = 'test@example.com';
-    process.env.PW = 'password';
+    process.env.BRING_EMAIL = 'test@example.com';
+    process.env.BRING_PASSWORD = 'password';
 
     mockBringLogin.mockResolvedValue(undefined); // Simulate successful login
     mockBringLoadLists.mockResolvedValue([]); // Simulate successful API call after login
@@ -47,11 +51,12 @@ describe('BringClient Automatic Login', () => {
 
     expect(mockBringLogin).toHaveBeenCalledTimes(1);
     expect(mockBringLoadLists).toHaveBeenCalledTimes(1);
+    expect(mockBringOptions).toContainEqual({ mail: 'test@example.com', password: 'password' });
   });
 
   it('should attempt login only once for multiple API calls if successful', async () => {
-    process.env.MAIL = 'test@example.com';
-    process.env.PW = 'password';
+    process.env.BRING_EMAIL = 'test@example.com';
+    process.env.BRING_PASSWORD = 'password';
 
     mockBringLogin.mockResolvedValue(undefined);
     mockBringLoadLists.mockResolvedValue([]);
@@ -65,8 +70,8 @@ describe('BringClient Automatic Login', () => {
   });
 
   it('should fail the API call if automatic login fails due to invalid credentials', async () => {
-    process.env.MAIL = 'wrong@example.com';
-    process.env.PW = 'wrongpassword';
+    process.env.BRING_EMAIL = 'wrong@example.com';
+    process.env.BRING_PASSWORD = 'wrongpassword';
     const loginError = new Error('Invalid Bring credentials');
     mockBringLogin.mockRejectedValue(loginError); // Simulate failed login
 
@@ -78,8 +83,8 @@ describe('BringClient Automatic Login', () => {
   });
 
   it('should re-attempt login on a subsequent API call if the first login attempt failed', async () => {
-    process.env.MAIL = 'firstfail@example.com';
-    process.env.PW = 'password';
+    process.env.BRING_EMAIL = 'firstfail@example.com';
+    process.env.BRING_PASSWORD = 'password';
     const loginError = new Error('Login failed initially');
 
     // First attempt: Login fails
@@ -96,6 +101,29 @@ describe('BringClient Automatic Login', () => {
 
     expect(mockBringLogin).toHaveBeenCalledTimes(2); // Login attempted twice
     expect(mockBringLoadLists).toHaveBeenCalledTimes(1); // API call succeeds after second login
+  });
+
+  it('should fall back to legacy MAIL and PW credentials', () => {
+    process.env.MAIL = 'legacy@example.com';
+    process.env.PW = 'legacy-password';
+
+    new BringClient();
+
+    expect(mockBringOptions).toContainEqual({
+      mail: 'legacy@example.com',
+      password: 'legacy-password',
+    });
+  });
+
+  it('should prefer BRING_EMAIL and BRING_PASSWORD over legacy aliases', () => {
+    process.env.BRING_EMAIL = 'new@example.com';
+    process.env.BRING_PASSWORD = 'new-password';
+    process.env.MAIL = 'legacy@example.com';
+    process.env.PW = 'legacy-password';
+
+    new BringClient();
+
+    expect(mockBringOptions).toContainEqual({ mail: 'new@example.com', password: 'new-password' });
   });
 });
 
@@ -118,17 +146,16 @@ describe('MCP Bring! Server - Tool Registration (Post-Login Refactor)', () => {
   it("should no longer register a dedicated 'login' tool", async () => {
     // Simulate server loading to check registered tools
     // This might require mocking BringClient or its methods if loadServer uses them
-    process.env.MAIL = 'test@example.com'; // Needed for BringClient instantiation
-    process.env.PW = 'password';
+    process.env.BRING_EMAIL = 'test@example.com'; // Needed for BringClient instantiation
+    process.env.BRING_PASSWORD = 'password';
     mockBringLogin.mockResolvedValue(undefined); // Prevent login issues during server load
 
     await loadServer(); // This populates mockTools
 
     const loginTool = getTool('login');
     expect(loginTool).toBeUndefined(); // The login tool should not be registered
-    expect(mockMcpServerInstance.tool).not.toHaveBeenCalledWith(
+    expect(mockMcpServerInstance.registerTool).not.toHaveBeenCalledWith(
       'login',
-      expect.any(String),
       expect.any(Object),
       expect.any(Function),
     );

--- a/tests/bringClient.spec.ts
+++ b/tests/bringClient.spec.ts
@@ -32,8 +32,8 @@ let sentBodies: string[] = [];
 describe('BringClient functionality', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env.MAIL = 'test@example.com';
-    process.env.PW = 'pw';
+    process.env.BRING_EMAIL = 'test@example.com';
+    process.env.BRING_PASSWORD = 'pw';
     // saveItem/removeItem/moveToRecentList now build their own escaped form
     // body instead of delegating to bring-shopping, so the suite has to stub
     // fetch. Without this these tests reach api.getbring.com for real and fail

--- a/tests/escaping.spec.ts
+++ b/tests/escaping.spec.ts
@@ -27,8 +27,8 @@ let sent: { url: string; body: string }[] = [];
 describe('legacy list mutation encoding', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env.MAIL = 'test@example.com';
-    process.env.PW = 'pw';
+    process.env.BRING_EMAIL = 'test@example.com';
+    process.env.BRING_PASSWORD = 'pw';
     sent = [];
     global.fetch = jest.fn().mockImplementation((url: string, init: { body?: string }) => {
       sent.push({ url: String(url), body: String(init?.body ?? '') });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -77,20 +77,40 @@ jest.mock('../src/bringClient.js', () => {
 export interface McpTool {
   description: string;
   schema: Record<string, unknown>;
-  callback: (...args: Record<string, unknown>[]) => Promise<{ content: { type: string; text: string }[] }>;
+  outputSchema: Record<string, unknown>;
+  annotations: Record<string, unknown>;
+  callback: (...args: Record<string, unknown>[]) => Promise<{
+    content: { type: string; text: string }[];
+    structuredContent?: Record<string, unknown>;
+    isError?: boolean;
+  }>;
 }
 
 export const mockTools: Map<string, McpTool> = new Map();
 
 export const mockMcpServerInstance = {
-  tool: jest.fn(
+  registerTool: jest.fn(
     (
       name: string,
-      description: string,
-      schema: Record<string, unknown>,
-      callback: (...args: Record<string, unknown>[]) => Promise<{ content: { type: string; text: string }[] }>,
+      config: {
+        description?: string;
+        inputSchema?: Record<string, unknown>;
+        outputSchema?: Record<string, unknown>;
+        annotations?: Record<string, unknown>;
+      },
+      callback: (...args: Record<string, unknown>[]) => Promise<{
+        content: { type: string; text: string }[];
+        structuredContent?: Record<string, unknown>;
+        isError?: boolean;
+      }>,
     ) => {
-      mockTools.set(name, { description, schema, callback });
+      mockTools.set(name, {
+        description: config.description ?? '',
+        schema: config.inputSchema ?? {},
+        outputSchema: config.outputSchema ?? {},
+        annotations: config.annotations ?? {},
+        callback,
+      });
     },
   ),
   connect: jest.fn<() => Promise<void>>(),
@@ -105,8 +125,8 @@ jest.mock('dotenv/config', () => ({}));
 
 export async function loadServer() {
   jest.resetModules();
-  process.env.MAIL = 'test@example.com';
-  process.env.PW = 'testpassword';
+  process.env.BRING_EMAIL = 'test@example.com';
+  process.env.BRING_PASSWORD = 'testpassword';
   await import('../src/index.js');
 }
 
@@ -203,8 +223,8 @@ export function getTool(name: string): McpTool | undefined {
 //   jest.resetModules(); // Reset modules to ensure index.ts is re-evaluated
 
 //   // Set up process.env before index.ts is loaded
-//   process.env.MAIL = 'test@example.com';
-//   process.env.PW = 'testpassword';
+//   process.env.BRING_EMAIL = 'test@example.com';
+//   process.env.BRING_PASSWORD = 'testpassword';
 
 //   // Dynamically import index.ts AFTER mocks are set up
 //   // The path to index.js needs to be relative to this helpers.ts file,

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -30,12 +30,17 @@ describe('MCP Bring! Server - Image Tools', () => {
     });
 
     it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'saveItemImage',
-        'Save an image for an item. Provide the image as base64-encoded data (maximum decoded size: 5 MiB).',
         expect.objectContaining({
-          itemId: expect.anything(),
-          imageData: expect.anything(),
+          description:
+            'Save an image for an item. Provide the image as base64-encoded data (maximum decoded size: 5 MiB).',
+          inputSchema: expect.objectContaining({
+            itemId: expect.anything(),
+            imageData: expect.anything(),
+          }),
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
         }),
         expect.any(Function),
       );
@@ -45,6 +50,7 @@ describe('MCP Bring! Server - Image Tools', () => {
         'Save an image for an item. Provide the image as base64-encoded data (maximum decoded size: 5 MiB).',
       );
       expect(tool?.schema).toMatchObject({ itemId: {}, imageData: {} });
+      expect(tool?.annotations).toMatchObject({ readOnlyHint: false, destructiveHint: true });
     });
 
     it('should call BringClient.saveItemImage and return success', async () => {
@@ -56,7 +62,10 @@ describe('MCP Bring! Server - Image Tools', () => {
       if (!tool) throw new Error('Tool saveItemImage not found');
       const result = await tool.callback({ itemId: fakeItemId, imageData: fakeImageData });
       expect(mockSaveItemImage).toHaveBeenCalledWith(fakeItemId, fakeImageData);
-      expect(result).toEqual({ content: [{ type: 'text', text: JSON.stringify(successResponse, null, 2) }] });
+      expect(result).toEqual({
+        content: [{ type: 'text', text: JSON.stringify(successResponse, null, 2) }],
+        structuredContent: { result: successResponse },
+      });
     });
 
     it('should return an error message on failed saveItemImage', async () => {
@@ -68,16 +77,23 @@ describe('MCP Bring! Server - Image Tools', () => {
       if (!tool) throw new Error('Tool saveItemImage not found');
       const result = await tool.callback({ itemId: fakeItemId, imageData: fakeImageData });
       expect(mockSaveItemImage).toHaveBeenCalledWith(fakeItemId, fakeImageData);
-      expect(result).toEqual({ content: [{ type: 'text', text: `Failed to save item image: ${errorMessage}` }] });
+      expect(result).toEqual({
+        content: [{ type: 'text', text: `Failed to save item image: ${errorMessage}` }],
+        isError: true,
+      });
     });
   });
 
   describe('bring.removeItemImage tool', () => {
     it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'removeItemImage',
-        'Remove an image from an item on a shopping list.',
-        expect.objectContaining({ itemId: expect.anything() }),
+        expect.objectContaining({
+          description: 'Remove an image from an item on a shopping list.',
+          inputSchema: expect.objectContaining({ itemId: expect.anything() }),
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
+        }),
         expect.any(Function),
       );
       const tool = getTool('removeItemImage');
@@ -94,7 +110,10 @@ describe('MCP Bring! Server - Image Tools', () => {
       if (!tool) throw new Error('Tool removeItemImage not found');
       const result = await tool.callback({ itemId: fakeItemId });
       expect(mockRemoveItemImage).toHaveBeenCalledWith(fakeItemId);
-      expect(result).toEqual({ content: [{ type: 'text', text: JSON.stringify(successResponse, null, 2) }] });
+      expect(result).toEqual({
+        content: [{ type: 'text', text: JSON.stringify(successResponse, null, 2) }],
+        structuredContent: { result: successResponse },
+      });
     });
 
     it('should return an error message on failed removeItemImage', async () => {
@@ -105,7 +124,10 @@ describe('MCP Bring! Server - Image Tools', () => {
       if (!tool) throw new Error('Tool removeItemImage not found');
       const result = await tool.callback({ itemId: fakeItemId });
       expect(mockRemoveItemImage).toHaveBeenCalledWith(fakeItemId);
-      expect(result).toEqual({ content: [{ type: 'text', text: `Failed to remove item image: ${errorMessage}` }] });
+      expect(result).toEqual({
+        content: [{ type: 'text', text: `Failed to remove item image: ${errorMessage}` }],
+        isError: true,
+      });
     });
   });
 });

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -45,8 +45,8 @@ describe('MCP Bring! Server - Integration Tests (Main Entry Point)', () => {
   });
 
   it('should initialize StdioServerTransport and connect McpServer when env vars are set', async () => {
-    process.env.MAIL = 'test@example.com';
-    process.env.PW = 'password';
+    process.env.BRING_EMAIL = 'test@example.com';
+    process.env.BRING_PASSWORD = 'password';
 
     // Dynamically import to trigger script execution
     await import('../src/index.js');
@@ -60,43 +60,53 @@ describe('MCP Bring! Server - Integration Tests (Main Entry Point)', () => {
     expect(mockExit).not.toHaveBeenCalled();
   });
 
-  it('should log an error and exit if MAIL environment variable is missing', async () => {
-    delete process.env.MAIL; // MAIL is missing
-    process.env.PW = 'password';
+  it('should log an error and exit if BRING_EMAIL and its legacy alias are missing', async () => {
+    delete process.env.BRING_EMAIL;
+    delete process.env.MAIL;
+    process.env.BRING_PASSWORD = 'password';
 
     await import('../src/index.js');
 
-    expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Missing MAIL or PW environment variables'));
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Missing BRING_EMAIL or BRING_PASSWORD environment variables'),
+    );
     expect(mockExit).toHaveBeenCalledWith(1);
     expect(mockMcpServerInstance.connect).not.toHaveBeenCalled();
   });
 
-  it('should log an error and exit if PW environment variable is missing', async () => {
-    process.env.MAIL = 'test@example.com';
-    delete process.env.PW; // PW is missing
+  it('should log an error and exit if BRING_PASSWORD and its legacy alias are missing', async () => {
+    process.env.BRING_EMAIL = 'test@example.com';
+    delete process.env.BRING_PASSWORD;
+    delete process.env.PW;
 
     await import('../src/index.js');
 
-    expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Missing MAIL or PW environment variables'));
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Missing BRING_EMAIL or BRING_PASSWORD environment variables'),
+    );
     expect(mockExit).toHaveBeenCalledWith(1);
     expect(mockMcpServerInstance.connect).not.toHaveBeenCalled();
   });
 
-  it('should log an error and exit if both MAIL and PW environment variables are missing', async () => {
+  it('should log an error and exit if all supported credential environment variables are missing', async () => {
+    delete process.env.BRING_EMAIL;
+    delete process.env.BRING_PASSWORD;
     delete process.env.MAIL;
     delete process.env.PW;
 
     await import('../src/index.js');
 
-    expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Missing MAIL or PW environment variables'));
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Missing BRING_EMAIL or BRING_PASSWORD environment variables'),
+    );
     expect(mockExit).toHaveBeenCalledWith(1);
     expect(mockMcpServerInstance.connect).not.toHaveBeenCalled();
   });
 
   // Test the catch block of main
   it('should log fatal error and exit if server.connect throws', async () => {
-    process.env.MAIL = 'test@example.com';
-    process.env.PW = 'password';
+    process.env.BRING_EMAIL = 'test@example.com';
+    process.env.BRING_PASSWORD = 'password';
 
     const connectError = new Error('Connection failed');
     mockMcpServerInstance.connect.mockRejectedValueOnce(connectError);
@@ -106,6 +116,18 @@ describe('MCP Bring! Server - Integration Tests (Main Entry Point)', () => {
     expect(mockMcpServerInstance.connect).toHaveBeenCalledTimes(1);
     expect(mockConsoleError).toHaveBeenCalledWith('Fatal error starting MCP server:', connectError);
     expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('should support MAIL and PW as deprecated aliases', async () => {
+    delete process.env.BRING_EMAIL;
+    delete process.env.BRING_PASSWORD;
+    process.env.MAIL = 'legacy@example.com';
+    process.env.PW = 'legacy-password';
+
+    await import('../src/index.js');
+
+    expect(mockMcpServerInstance.connect).toHaveBeenCalledTimes(1);
+    expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Deprecation warning'));
   });
 
   const expectedToolNames = [
@@ -128,19 +150,28 @@ describe('MCP Bring! Server - Integration Tests (Main Entry Point)', () => {
   ];
 
   it('should register all expected tools on McpServer', async () => {
-    process.env.MAIL = 'test@example.com';
-    process.env.PW = 'password';
+    process.env.BRING_EMAIL = 'test@example.com';
+    process.env.BRING_PASSWORD = 'password';
 
     await import('../src/index.js');
 
-    expect(mockMcpServerInstance.tool).toHaveBeenCalledTimes(expectedToolNames.length);
+    expect(mockMcpServerInstance.registerTool).toHaveBeenCalledTimes(expectedToolNames.length);
 
     for (const toolName of expectedToolNames) {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         toolName,
-        expect.any(String), // description
-        expect.any(Object), // schema
-        expect.any(Function), // callback
+        expect.objectContaining({
+          description: expect.any(String),
+          inputSchema: expect.any(Object),
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({
+            readOnlyHint: expect.any(Boolean),
+            destructiveHint: expect.any(Boolean),
+            idempotentHint: expect.any(Boolean),
+            openWorldHint: true,
+          }),
+        }),
+        expect.any(Function),
       );
     }
   });

--- a/tests/items.spec.ts
+++ b/tests/items.spec.ts
@@ -28,10 +28,14 @@ describe('MCP Bring! Server - Item Tools', () => {
 
   describe('bring.getItems tool', () => {
     it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'getItems',
-        'Get all items from a specific shopping list.', // From src/index.ts
-        expect.objectContaining({ listUuid: expect.anything() }), // Adjusted schema check
+        expect.objectContaining({
+          description: 'Get all items from a specific shopping list.',
+          inputSchema: expect.objectContaining({ listUuid: expect.anything() }),
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
+        }),
         expect.any(Function),
       );
       const tool = getTool('getItems');
@@ -55,6 +59,7 @@ describe('MCP Bring! Server - Item Tools', () => {
       expect(mockGetItems).toHaveBeenCalledWith(fakeListUuid);
       expect(result).toEqual({
         content: [{ type: 'text', text: JSON.stringify(fakeItemsExpectedByTool, null, 2) }],
+        structuredContent: { result: fakeItemsExpectedByTool },
       });
     });
 
@@ -114,16 +119,21 @@ describe('MCP Bring! Server - Item Tools', () => {
       expect(mockGetItems).toHaveBeenCalledWith(fakeListUuid);
       expect(result).toEqual({
         content: [{ type: 'text', text: `Failed to get items: ${errorMessage}` }],
+        isError: true,
       });
     });
   });
 
   describe('bring.getItemsDetails tool', () => {
     it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'getItemsDetails',
-        'Get details for items in a list. (Take listUuid)', // Corrected description
-        expect.objectContaining({ listUuid: expect.anything() }), // Adjusted schema check
+        expect.objectContaining({
+          description: 'Get details for items in a list. (Take listUuid)',
+          inputSchema: expect.objectContaining({ listUuid: expect.anything() }),
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
+        }),
         expect.any(Function),
       );
       const tool = getTool('getItemsDetails');
@@ -145,6 +155,7 @@ describe('MCP Bring! Server - Item Tools', () => {
       expect(mockGetItemsDetails).toHaveBeenCalledWith(fakeListUuid); // Corrected: only expect listUuid
       expect(result).toEqual({
         content: [{ type: 'text', text: JSON.stringify(fakeItemDetails, null, 2) }],
+        structuredContent: { result: fakeItemDetails },
       });
     });
 
@@ -157,19 +168,27 @@ describe('MCP Bring! Server - Item Tools', () => {
       if (!tool) throw new Error('Tool getItemsDetails not found');
       const result = await tool.callback({ listUuid: fakeListUuid }); // Corrected: only pass listUuid
       expect(mockGetItemsDetails).toHaveBeenCalledWith(fakeListUuid); // Corrected: only expect listUuid
-      expect(result).toEqual({ content: [{ type: 'text', text: `Failed to get item details: ${errorMessage}` }] });
+      expect(result).toEqual({
+        content: [{ type: 'text', text: `Failed to get item details: ${errorMessage}` }],
+        isError: true,
+      });
     });
   });
 
   describe('bring.saveItem tool', () => {
     it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'saveItem',
-        'Save an item to a shopping list. Use the "specification" parameter to add details like quantity or type (e.g., itemName: "Milk", specification: "2 liters").',
         expect.objectContaining({
-          listUuid: expect.anything(),
-          itemName: expect.anything(),
-          specification: expect.anything(),
+          description:
+            'Save an item to a shopping list. Use the "specification" parameter to add details like quantity or type (e.g., itemName: "Milk", specification: "2 liters").',
+          inputSchema: expect.objectContaining({
+            listUuid: expect.anything(),
+            itemName: expect.anything(),
+            specification: expect.anything(),
+          }),
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
         }),
         expect.any(Function),
       );
@@ -198,6 +217,7 @@ describe('MCP Bring! Server - Item Tools', () => {
       expect(mockSaveItem).toHaveBeenCalledWith(fakeListUuid, fakeItemName, fakeItemSpec);
       expect(result).toEqual({
         content: [{ type: 'text', text: `Item saved: ${JSON.stringify(savedItemConfirmation)}` }],
+        structuredContent: { result: savedItemConfirmation },
       });
     });
 
@@ -215,16 +235,23 @@ describe('MCP Bring! Server - Item Tools', () => {
         specification: fakeItemSpec,
       });
       expect(mockSaveItem).toHaveBeenCalledWith(fakeListUuid, fakeItemName, fakeItemSpec);
-      expect(result).toEqual({ content: [{ type: 'text', text: `Failed to save item: ${errorMessage}` }] });
+      expect(result).toEqual({
+        content: [{ type: 'text', text: `Failed to save item: ${errorMessage}` }],
+        isError: true,
+      });
     });
   });
 
   describe('bring.removeItem tool', () => {
     it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'removeItem',
-        'Remove an item from a specific shopping list.',
-        expect.objectContaining({ listUuid: expect.anything(), itemId: expect.anything() }),
+        expect.objectContaining({
+          description: 'Remove an item from a specific shopping list.',
+          inputSchema: expect.objectContaining({ listUuid: expect.anything(), itemId: expect.anything() }),
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
+        }),
         expect.any(Function),
       );
       const tool = getTool('removeItem');
@@ -246,6 +273,7 @@ describe('MCP Bring! Server - Item Tools', () => {
       expect(mockRemoveItem).toHaveBeenCalledWith(fakeListUuid, fakeItemId);
       expect(result).toEqual({
         content: [{ type: 'text', text: JSON.stringify(successResponse, null, 2) }],
+        structuredContent: { result: successResponse },
       });
     });
 
@@ -262,16 +290,21 @@ describe('MCP Bring! Server - Item Tools', () => {
       expect(mockRemoveItem).toHaveBeenCalledWith(fakeListUuid, fakeItemId);
       expect(result).toEqual({
         content: [{ type: 'text', text: `Failed to remove item: ${errorMessage}` }],
+        isError: true,
       });
     });
   });
 
   describe('bring.moveToRecentList tool', () => {
     it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'moveToRecentList',
-        'Move an item from a shopping list to the recently used items list.',
-        expect.objectContaining({ listUuid: expect.anything(), itemId: expect.anything() }),
+        expect.objectContaining({
+          description: 'Move an item from a shopping list to the recently used items list.',
+          inputSchema: expect.objectContaining({ listUuid: expect.anything(), itemId: expect.anything() }),
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
+        }),
         expect.any(Function),
       );
       const tool = getTool('moveToRecentList');
@@ -293,6 +326,7 @@ describe('MCP Bring! Server - Item Tools', () => {
       expect(mockMoveToRecentList).toHaveBeenCalledWith(fakeListUuid, fakeItemId);
       expect(result).toEqual({
         content: [{ type: 'text', text: JSON.stringify(successResponse, null, 2) }],
+        structuredContent: { result: successResponse },
       });
     });
 
@@ -309,16 +343,22 @@ describe('MCP Bring! Server - Item Tools', () => {
       expect(mockMoveToRecentList).toHaveBeenCalledWith(fakeListUuid, fakeItemId);
       expect(result).toEqual({
         content: [{ type: 'text', text: `Failed to move item to recent list: ${errorMessage}` }],
+        isError: true,
       });
     });
   });
 
   describe('bring.saveItemBatch tool', () => {
     it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'saveItemBatch',
-        'Save multiple items to a shopping list. For each item, you can provide an "itemName" and an optional "specification" for details like quantity or type (input e.g., [{ "itemName": "Eggs", "specification": "dozen" },{ "itemName":"Apples", "specification": "10" }]).',
-        expect.objectContaining({ listUuid: expect.anything(), items: expect.anything() }),
+        expect.objectContaining({
+          description:
+            'Save multiple items to a shopping list. For each item, you can provide an "itemName" and an optional "specification" for details like quantity or type (input e.g., [{ "itemName": "Eggs", "specification": "dozen" },{ "itemName":"Apples", "specification": "10" }]).',
+          inputSchema: expect.objectContaining({ listUuid: expect.anything(), items: expect.anything() }),
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
+        }),
         expect.any(Function),
       );
       const tool = getTool('saveItemBatch');
@@ -346,6 +386,7 @@ describe('MCP Bring! Server - Item Tools', () => {
       expect(mockSaveItemBatch).toHaveBeenCalledWith(fakeListUuid, fakeItems);
       expect(result).toEqual({
         content: [{ type: 'text', text: `Batch items saved: ${JSON.stringify(successResponse)}` }],
+        structuredContent: { result: successResponse },
       });
     });
 
@@ -362,6 +403,7 @@ describe('MCP Bring! Server - Item Tools', () => {
       expect(mockSaveItemBatch).toHaveBeenCalledWith(fakeListUuid, fakeItems);
       expect(result).toEqual({
         content: [{ type: 'text', text: `Failed to save batch items: ${errorMessage}` }],
+        isError: true,
       });
     });
   });
@@ -371,10 +413,14 @@ describe('MCP Bring! Server - Item Tools', () => {
     const itemNamesToDelete = ['ItemA', 'ItemB'];
 
     it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'deleteMultipleItemsFromList',
-        'Delete multiple items from a specific shopping list by their names.',
-        expect.objectContaining({ listUuid: expect.anything(), itemNames: expect.anything() }),
+        expect.objectContaining({
+          description: 'Delete multiple items from a specific shopping list by their names.',
+          inputSchema: expect.objectContaining({ listUuid: expect.anything(), itemNames: expect.anything() }),
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
+        }),
         expect.any(Function),
       );
       const tool = getTool('deleteMultipleItemsFromList');
@@ -405,6 +451,7 @@ describe('MCP Bring! Server - Item Tools', () => {
       // Uses transformResult from itemTools.ts
       expect(result).toEqual({
         content: [{ type: 'text', text: `Multiple items deleted: ${JSON.stringify(mockSuccessResponse)}` }],
+        structuredContent: { result: mockSuccessResponse },
       });
     });
 
@@ -422,6 +469,7 @@ describe('MCP Bring! Server - Item Tools', () => {
 
       expect(result).toEqual({
         content: [{ type: 'text', text: `Failed to delete multiple items: ${errorMessage}` }],
+        isError: true,
       });
     });
   });

--- a/tests/lists.spec.ts
+++ b/tests/lists.spec.ts
@@ -22,16 +22,21 @@ describe('MCP Bring! Server - List Tools', () => {
 
   describe('bring.loadLists tool', () => {
     it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'loadLists',
-        'Load all shopping lists from Bring!',
-        {}, // Schema for no-param tool
+        expect.objectContaining({
+          description: 'Load all shopping lists from Bring!',
+          inputSchema: {},
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
+        }),
         expect.any(Function), // Callback
       );
       const tool = getTool('loadLists');
       expect(tool).toBeDefined();
       expect(tool?.description).toBe('Load all shopping lists from Bring!');
       expect(tool?.schema).toEqual({});
+      expect(tool?.annotations).toMatchObject({ readOnlyHint: true, destructiveHint: false });
     });
 
     it('should call BringClient.loadLists and return lists on success', async () => {
@@ -48,6 +53,7 @@ describe('MCP Bring! Server - List Tools', () => {
       expect(mockLoadLists).toHaveBeenCalledTimes(1);
       expect(result).toEqual({
         content: [{ type: 'text', text: JSON.stringify(fakeLists, null, 2) }],
+        structuredContent: { result: fakeLists },
       });
     });
 
@@ -62,6 +68,7 @@ describe('MCP Bring! Server - List Tools', () => {
       expect(mockLoadLists).toHaveBeenCalledTimes(1);
       expect(result).toEqual({
         content: [{ type: 'text', text: `Failed to load lists: ${errorMessage}` }],
+        isError: true,
       });
     });
   });

--- a/tests/users.spec.ts
+++ b/tests/users.spec.ts
@@ -35,10 +35,14 @@ describe('MCP Bring! Server - User Tools', () => {
     const toolSchema = { listUuid: expect.any(Object) }; // Zod string
 
     it('should be registered correctly', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'getAllUsersFromList',
-        'Get all users associated with a specific shopping list.',
-        toolSchema,
+        expect.objectContaining({
+          description: 'Get all users associated with a specific shopping list.',
+          inputSchema: toolSchema,
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
+        }),
         expect.any(Function),
       );
       const tool = getTool('getAllUsersFromList');
@@ -58,7 +62,10 @@ describe('MCP Bring! Server - User Tools', () => {
       if (!tool) throw new Error('Tool getAllUsersFromList not found');
       const result = await tool.callback({ listUuid: fakeListUuid });
       expect(mockGetAllUsersFromList).toHaveBeenCalledWith(fakeListUuid);
-      expect(result).toEqual({ content: [{ type: 'text', text: JSON.stringify(fakeUsers, null, 2) }] });
+      expect(result).toEqual({
+        content: [{ type: 'text', text: JSON.stringify(fakeUsers, null, 2) }],
+        structuredContent: { result: fakeUsers },
+      });
     });
 
     it('should return error on failure', async () => {
@@ -70,6 +77,7 @@ describe('MCP Bring! Server - User Tools', () => {
       const result = await tool.callback({ listUuid: fakeListUuid });
       expect(result).toEqual({
         content: [{ type: 'text', text: `Failed to get all users from list: ${error.message}` }],
+        isError: true,
       });
     });
   });
@@ -77,10 +85,14 @@ describe('MCP Bring! Server - User Tools', () => {
   // Test for getUserSettings
   describe('bring.getUserSettings tool', () => {
     it('should be registered correctly', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'getUserSettings',
-        'Get the settings for the current authenticated user.',
-        {},
+        expect.objectContaining({
+          description: 'Get the settings for the current authenticated user.',
+          inputSchema: {},
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
+        }),
         expect.any(Function),
       );
       const tool = getTool('getUserSettings');
@@ -96,7 +108,10 @@ describe('MCP Bring! Server - User Tools', () => {
       if (!tool) throw new Error('Tool getUserSettings not found');
       const result = await tool.callback({});
       expect(mockGetUserSettings).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({ content: [{ type: 'text', text: JSON.stringify(fakeSettings, null, 2) }] });
+      expect(result).toEqual({
+        content: [{ type: 'text', text: JSON.stringify(fakeSettings, null, 2) }],
+        structuredContent: { result: fakeSettings },
+      });
     });
 
     it('should return error on failure', async () => {
@@ -105,17 +120,24 @@ describe('MCP Bring! Server - User Tools', () => {
       const tool = getTool('getUserSettings');
       if (!tool) throw new Error('Tool getUserSettings not found');
       const result = await tool.callback({});
-      expect(result).toEqual({ content: [{ type: 'text', text: `Failed to get user settings: ${error.message}` }] });
+      expect(result).toEqual({
+        content: [{ type: 'text', text: `Failed to get user settings: ${error.message}` }],
+        isError: true,
+      });
     });
   });
 
   // Test for getPendingInvitations
   describe('bring.getPendingInvitations tool', () => {
     it('should be registered correctly', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'getPendingInvitations',
-        'Get any pending invitations for the authenticated user to join shopping lists.',
-        {},
+        expect.objectContaining({
+          description: 'Get any pending invitations for the authenticated user to join shopping lists.',
+          inputSchema: {},
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
+        }),
         expect.any(Function),
       );
       const tool = getTool('getPendingInvitations');
@@ -131,7 +153,10 @@ describe('MCP Bring! Server - User Tools', () => {
       if (!tool) throw new Error('Tool getPendingInvitations not found');
       const result = await tool.callback({});
       expect(mockGetPendingInvitations).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({ content: [{ type: 'text', text: JSON.stringify(fakeInvitations, null, 2) }] });
+      expect(result).toEqual({
+        content: [{ type: 'text', text: JSON.stringify(fakeInvitations, null, 2) }],
+        structuredContent: { result: fakeInvitations },
+      });
     });
 
     it('should return error on failure', async () => {
@@ -142,6 +167,7 @@ describe('MCP Bring! Server - User Tools', () => {
       const result = await tool.callback({});
       expect(result).toEqual({
         content: [{ type: 'text', text: `Failed to get pending invitations: ${error.message}` }],
+        isError: true,
       });
     });
   });
@@ -149,10 +175,15 @@ describe('MCP Bring! Server - User Tools', () => {
   // Test for getDefaultList
   describe('bring.getDefaultList tool', () => {
     it('should be registered correctly', () => {
-      expect(mockMcpServerInstance.tool).toHaveBeenCalledWith(
+      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
         'getDefaultList',
-        'Get the UUID of the default shopping list for the authenticated user. Use this if the user does not ask for a special list.',
-        {}, // No schema for this tool
+        expect.objectContaining({
+          description:
+            'Get the UUID of the default shopping list for the authenticated user. Use this if the user does not ask for a special list.',
+          inputSchema: {},
+          outputSchema: expect.objectContaining({ result: expect.anything() }),
+          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
+        }),
         expect.any(Function),
       );
       const tool = getTool('getDefaultList');
@@ -180,6 +211,7 @@ describe('MCP Bring! Server - User Tools', () => {
       expect(mockGetUserSettings).toHaveBeenCalledTimes(1);
       expect(result).toEqual({
         content: [{ type: 'text', text: 'default-list-uuid-123' }],
+        structuredContent: { result: 'default-list-uuid-123' },
       });
     });
 
@@ -204,6 +236,9 @@ describe('MCP Bring! Server - User Tools', () => {
             text: 'No default list is configured. Set one in the Bring app, or call loadLists to choose.',
           },
         ],
+        structuredContent: {
+          result: 'No default list is configured. Set one in the Bring app, or call loadLists to choose.',
+        },
       });
     });
 
@@ -217,6 +252,7 @@ describe('MCP Bring! Server - User Tools', () => {
       expect(mockGetUserSettings).toHaveBeenCalledTimes(1);
       expect(result).toEqual({
         content: [{ type: 'text', text: `Failed to get default list UUID: ${error.message}` }],
+        isError: true,
       });
     });
 
@@ -236,6 +272,9 @@ describe('MCP Bring! Server - User Tools', () => {
             text: 'No default list is configured. Set one in the Bring app, or call loadLists to choose.',
           },
         ],
+        structuredContent: {
+          result: 'No default list is configured. Set one in the Bring app, or call loadLists to choose.',
+        },
       });
     });
 
@@ -258,6 +297,7 @@ describe('MCP Bring! Server - User Tools', () => {
       expect(mockLoadLists).toHaveBeenCalledTimes(1);
       expect(result).toEqual({
         content: [{ type: 'text', text: soleListUuid }],
+        structuredContent: { result: soleListUuid },
       });
     });
 


### PR DESCRIPTION
## Summary

- use `BRING_EMAIL` and `BRING_PASSWORD` as the primary credential variables while retaining deprecated `MAIL`/`PW` aliases
- migrate all 16 MCP tools from deprecated `server.tool()` calls to `server.registerTool()`
- add output schemas, structured content, explicit error results, and read/write annotations
- update documentation and tests for the new behavior

## Verification

- `npm run test` — 79 tests passed
- `npm run build` — passed
- `npm run test:ci` — passed, including formatting, ESLint, Jest, and coverage
- MCP STDIO smoke test — all 16 tools published with output schemas and annotations
- live Bring! API smoke test — create, read, remove, and final-state verification passed