### PR TITLE
Migrate to MCP SDK v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This project implements a local Model Context Protocol (MCP) server in TypeScript that exposes the functionalities of the Bring! shopping list API. It enables applications like Claude Desktop to interact with your Bring! shopping lists using standardized MCP tools.
 
-The server integrates the `bring-shopping` npm package for Bring! API access and leverages `@modelcontextprotocol/sdk` to provide an MCP-compliant server interface.
+The server integrates the `bring-shopping` npm package for Bring! API access and uses the MCP TypeScript SDK v2 server package to provide an MCP-compliant interface.
 
 > **Disclaimer:**  
 > This is a personal project. I am not affiliated with Bring! Labs AG in any way.  
@@ -49,6 +49,9 @@ This is the recommended and most portable configuration. It ensures you always u
   - 🌐 Load translations & catalog
   - 📨 Retrieve pending invitations
 - Communicates via STDIO (for use with Claude Desktop or MCP Inspector)
+- Supports MCP protocol revision `2026-07-28` while continuing to serve legacy 2025 clients
+- Publishes tool titles, annotations, concrete input/output schemas, and machine-readable structured results
+- Marks tool failures with `isError: true` so clients can distinguish them from successful calls
 - Supports Bring! credentials via `.env` file or injected environment variables
 
 ### Available Tools
@@ -117,7 +120,7 @@ Launch the MCP server with:
 node build/src/index.js
 ```
 
-If successful, you'll see: `MCP server for Bring! API is running on STDIO` (on `stderr`).
+If successful, you'll see: `MCP server for Bring! API v<version> is running on STDIO` (on `stderr`).
 
 ---
 
@@ -182,7 +185,8 @@ npm run build
 
 ### Key Dependencies and Tools
 
-- `@modelcontextprotocol/sdk`: For MCP server implementation
+- `@modelcontextprotocol/server`: MCP SDK v2 server and STDIO protocol dispatcher
+- `@modelcontextprotocol/client`: Development-only client used for end-to-end protocol compatibility tests
 - `@modelcontextprotocol/inspector`: Run on demand with `npx` for testing and debugging MCP servers
 - `bring-shopping`: Node.js wrapper for the Bring! API
 - `zod`: For schema definition and validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.9.2-beta",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "bring-shopping": "^2.0.1",
         "dotenv": "^17.4.0",
         "zod": "^4.3.6"
@@ -18,6 +18,7 @@
         "bring-mcp": "build/src/index.js"
       },
       "devDependencies": {
+        "@modelcontextprotocol/client": "^2.0.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^26.2.0",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
@@ -678,18 +679,6 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
-      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1248,75 +1237,48 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
-      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9 || ^2.0.5",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
+        "@modelcontextprotocol/core": "2.0.0",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
         "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
+        "node": ">=20"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "zod": "^4.2.0"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
+      "engines": {
+        "node": ">=20"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/pkce-challenge": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
       "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
       "engines": {
-        "node": ">=16.20.0"
+        "node": ">=20"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2094,19 +2056,6 @@
         "win32"
       ]
     },
-    "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -2146,45 +2095,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -2387,43 +2297,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/body-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
-      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^2.0.0",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.1",
-        "iconv-lite": "^0.7.2",
-        "on-finished": "^2.4.1",
-        "qs": "^6.15.2",
-        "raw-body": "^3.0.2",
-        "type-is": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/body-parser/node_modules/content-type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
-      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
@@ -2509,44 +2382,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -2775,28 +2610,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2804,45 +2617,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2857,6 +2636,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2902,15 +2682,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2933,31 +2704,11 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -2987,15 +2738,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/encodeurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -3004,36 +2746,6 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -3045,12 +2757,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3302,19 +3008,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -3327,6 +3025,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
       "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -3391,72 +3090,11 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
-      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3472,22 +3110,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
-      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -3528,27 +3150,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3606,24 +3207,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3646,15 +3229,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3675,30 +3249,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3707,19 +3257,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3803,18 +3340,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3854,65 +3379,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/hono": {
-      "version": "4.13.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
-      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -3922,22 +3394,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
-      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -3996,25 +3452,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -4066,12 +3505,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
-    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -4089,6 +3522,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -4759,6 +4193,7 @@
       "version": "6.2.9",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
       "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -4827,12 +4262,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4961,71 +4390,12 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/media-typer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
-      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
@@ -5077,6 +4447,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
@@ -5101,35 +4472,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/negotiator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
-      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/negotiator/node_modules/content-type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
-      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -5178,43 +4520,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5322,15 +4632,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5355,6 +4656,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5384,16 +4686,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5422,6 +4714,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -5548,19 +4850,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5588,50 +4877,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/qs": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
-      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/range-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
-      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/react-is-18": {
       "name": "react-is",
       "version": "18.3.1",
@@ -5653,15 +4898,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5690,28 +4926,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -5725,61 +4939,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5792,81 +4956,10 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
-      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4",
-        "side-channel-list": "^1.0.1",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -5934,15 +5027,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/string-length": {
@@ -6243,15 +5327,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -6375,37 +5450,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/type-is": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
-      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^2.0.0",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/type-is/node_modules/content-type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
-      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -6440,15 +5484,6 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
@@ -6544,15 +5579,6 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -6567,6 +5593,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6694,6 +5721,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -6821,15 +5849,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,12 +38,13 @@
     "bring-mcp": "build/src/index.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "bring-shopping": "^2.0.1",
     "dotenv": "^17.4.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^26.2.0",
     "@typescript-eslint/eslint-plugin": "^8.58.0",

--- a/src/bringClient.ts
+++ b/src/bringClient.ts
@@ -198,3 +198,22 @@ export class BringClient {
     return results;
   }
 }
+
+export type BringService = Pick<
+  BringClient,
+  | 'loadLists'
+  | 'getItems'
+  | 'getItemsDetails'
+  | 'saveItem'
+  | 'saveItemBatch'
+  | 'removeItem'
+  | 'moveToRecentList'
+  | 'saveItemImage'
+  | 'removeItemImage'
+  | 'getAllUsersFromList'
+  | 'getUserSettings'
+  | 'loadTranslations'
+  | 'loadCatalog'
+  | 'getPendingInvitations'
+  | 'deleteMultipleItemsFromList'
+>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,158 +1,55 @@
 #!/usr/bin/env node
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import { z, ZodRawShape, ZodObject } from 'zod';
-import { BringClient } from './bringClient.js';
 import 'dotenv/config';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
+import { BringClient } from './bringClient.js';
+import { readPackageVersion } from './packageInfo.js';
+import { createBringServer } from './server.js';
 
-import { registerListTools } from './tools/listTools.js';
-import { registerItemTools } from './tools/itemTools.js';
-import { registerUserTools } from './tools/userTools.js';
-import { registerCatalogTools } from './tools/catalogTools.js';
-
-const server = new McpServer({
-  name: 'bring',
-  version: '1.0.0',
-});
-
-// const bc = new BringClient(); // Moved into main
-
-// Define a type for content parts
-type McpContentPart = { type: 'text'; text: string; [key: string]: unknown };
-
-// Helper function to create a simple text response
-function textToolResult(text: string) {
-  const contentPart: McpContentPart = { type: 'text', text };
-  return { content: [contentPart] };
-}
-
-// Helper function to create a JSON response (as stringified text)
-function jsonToolResult(data: unknown) {
-  const contentPart: McpContentPart = { type: 'text', text: JSON.stringify(data, null, 2) ?? 'null' };
-  return { content: [contentPart] };
-}
-
-function structuredToolResult(data: unknown) {
-  return { result: data === undefined ? null : data };
-}
-
-const outputSchema = {
-  result: z.unknown().describe('The structured result returned by the Bring! API operation.'),
+export type BringCredentials = {
+  email: string;
+  password: string;
+  usesLegacyNames: boolean;
 };
 
-// Generic tool registration helper - Overloads
-export function registerTool<TParams extends ZodRawShape, TResult, TArgs = z.infer<ZodObject<TParams>>>(options: {
-  server: McpServer;
-  bc: BringClient;
-  name: string;
-  description: string;
-  schemaShape: TParams; // Non-optional for this overload
-  actionFn: (args: TArgs, bc: BringClient) => Promise<TResult>;
-  transformResult?: (result: TResult) => { content: McpContentPart[] };
-  failureMessage: string;
-  annotations: ToolAnnotations;
-}): void;
-export function registerTool<TResult>(options: {
-  server: McpServer;
-  bc: BringClient;
-  name: string;
-  description: string;
-  schemaShape?: undefined; // Schema is undefined for this overload
-  actionFn: (args: undefined, bc: BringClient) => Promise<TResult>; // Args are undefined
-  transformResult?: (result: TResult) => { content: McpContentPart[] };
-  failureMessage: string;
-  annotations: ToolAnnotations;
-}): void;
-// Implementation signature for registerTool
-export function registerTool(options: {
-  server: McpServer;
-  bc: BringClient;
-  name: string;
-  description: string;
-  schemaShape?: ZodRawShape;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  actionFn: (args: any, bc: BringClient) => Promise<any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  transformResult?: (result: any) => { content: McpContentPart[] };
-  failureMessage: string;
-  annotations: ToolAnnotations;
-}) {
-  const { server, bc, name, description, schemaShape, actionFn, transformResult, failureMessage, annotations } =
-    options;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const callback = async (args: any) => {
-    try {
-      const res = await actionFn(args, bc);
-      if (transformResult) {
-        return {
-          ...transformResult(res),
-          structuredContent: structuredToolResult(res),
-        };
-      }
-      return {
-        ...jsonToolResult(res),
-        structuredContent: structuredToolResult(res),
-      };
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      console.error(`${failureMessage}:`, error);
-      return {
-        ...textToolResult(`${failureMessage}: ${errorMessage}`),
-        isError: true,
-      };
-    }
-  };
-
-  server.registerTool(
-    name,
-    {
-      description,
-      inputSchema: schemaShape ?? {},
-      outputSchema,
-      annotations,
-    },
-    callback,
-  );
-}
-
-// Register login tool and other tools moved into main
-
-// Start the server
-async function main() {
-  const email = process.env.BRING_EMAIL ?? process.env.MAIL;
-  const password = process.env.BRING_PASSWORD ?? process.env.PW;
+export function resolveCredentials(environment: NodeJS.ProcessEnv = process.env): BringCredentials {
+  const email = environment.BRING_EMAIL ?? environment.MAIL;
+  const password = environment.BRING_PASSWORD ?? environment.PW;
 
   if (!email || !password) {
-    console.error(
+    throw new Error(
       'Missing BRING_EMAIL or BRING_PASSWORD environment variables. Please provide your Bring! credentials through the environment or a .env file.',
     );
-    process.exit(1);
-    return;
   }
 
-  if (!process.env.BRING_EMAIL || !process.env.BRING_PASSWORD) {
+  return {
+    email,
+    password,
+    usesLegacyNames: !environment.BRING_EMAIL || !environment.BRING_PASSWORD,
+  };
+}
+
+export function main(): void {
+  const credentials = resolveCredentials();
+  if (credentials.usesLegacyNames) {
     console.error(
       'Deprecation warning: MAIL and PW are legacy aliases. Please migrate to BRING_EMAIL and BRING_PASSWORD.',
     );
   }
 
-  const bc = new BringClient(email, password); // Instantiated after env check
-
-  // Register tools from modules
-  registerListTools(server, bc);
-  registerItemTools(server, bc);
-  registerUserTools(server, bc);
-  registerCatalogTools(server, bc);
-
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error('MCP server for Bring! API is running on STDIO');
+  const version = readPackageVersion();
+  serveStdio(() => createBringServer(new BringClient(credentials.email, credentials.password), version), {
+    legacy: 'serve',
+    onerror: (error) => console.error('MCP transport error:', error),
+  });
+  console.error(`MCP server for Bring! API v${version} is running on STDIO`);
 }
 
-main().catch((e) => {
-  console.error('Fatal error starting MCP server:', e);
-  process.exit(1);
-});
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error('Fatal error starting MCP server:', error);
+    process.exitCode = 1;
+  }
+}

--- a/src/packageInfo.ts
+++ b/src/packageInfo.ts
@@ -1,0 +1,20 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+type PackageMetadata = {
+  version?: unknown;
+};
+
+export function readPackageVersion(baseDirectory = __dirname): string {
+  const candidates = [resolve(baseDirectory, '../../package.json'), resolve(baseDirectory, '../package.json')];
+
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    const metadata = JSON.parse(readFileSync(candidate, 'utf8')) as PackageMetadata;
+    if (typeof metadata.version === 'string' && metadata.version.length > 0) {
+      return metadata.version;
+    }
+  }
+
+  throw new Error('Unable to determine the bring-mcp package version.');
+}

--- a/src/registerTool.ts
+++ b/src/registerTool.ts
@@ -1,0 +1,78 @@
+import {
+  McpServer,
+  type CallToolResult,
+  type TextContent,
+  type ToolAnnotations,
+  type ToolCallback,
+} from '@modelcontextprotocol/server';
+import { z } from 'zod';
+import type { BringService } from './bringClient.js';
+
+type ToolInputSchema = z.ZodObject<z.ZodRawShape>;
+type ToolOutputSchema = z.ZodType;
+
+export type RegisterToolOptions<TInput extends ToolInputSchema, TOutput extends ToolOutputSchema> = {
+  server: McpServer;
+  bc: BringService;
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: TInput;
+  outputSchema: TOutput;
+  actionFn: (args: z.output<TInput>, bc: BringService) => Promise<z.output<TOutput>>;
+  failureMessage: string;
+  annotations: ToolAnnotations;
+  formatText?: (result: z.output<TOutput>) => string;
+};
+
+function textContent(text: string): TextContent[] {
+  return [{ type: 'text', text }];
+}
+
+export function registerTool<TInput extends ToolInputSchema, TOutput extends ToolOutputSchema>(
+  options: RegisterToolOptions<TInput, TOutput>,
+): void {
+  const {
+    server,
+    bc,
+    name,
+    title,
+    description,
+    inputSchema,
+    outputSchema,
+    actionFn,
+    failureMessage,
+    annotations,
+    formatText,
+  } = options;
+
+  const callback = async (args: z.output<TInput>): Promise<CallToolResult> => {
+    try {
+      const result = await actionFn(args, bc);
+      const serialized = formatText ? formatText(result) : JSON.stringify(result, null, 2);
+      return {
+        content: textContent(serialized ?? 'null'),
+        structuredContent: result,
+      };
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(`${failureMessage}:`, error);
+      return {
+        content: textContent(`${failureMessage}: ${errorMessage}`),
+        isError: true,
+      };
+    }
+  };
+
+  server.registerTool<TOutput, TInput>(
+    name,
+    {
+      title,
+      description,
+      inputSchema,
+      outputSchema,
+      annotations,
+    },
+    callback as ToolCallback<TInput>,
+  );
+}

--- a/src/schemaShared.ts
+++ b/src/schemaShared.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+export const noArgsSchema = z.strictObject({});
+
 export const listUuidParam = {
   listUuid: z.string().uuid({ message: 'Invalid list UUID' }),
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,40 @@
+import { McpServer } from '@modelcontextprotocol/server';
+import type { BringService } from './bringClient.js';
+import { readPackageVersion } from './packageInfo.js';
+import { registerCatalogTools } from './tools/catalogTools.js';
+import { registerItemTools } from './tools/itemTools.js';
+import { registerListTools } from './tools/listTools.js';
+import { registerUserTools } from './tools/userTools.js';
+
+export const SERVER_INSTRUCTIONS = [
+  'Use getDefaultList when the user does not name a shopping list.',
+  'If no default list is configured, call loadLists and let the user choose before changing data.',
+  'Use the listUuid returned by loadLists or getDefaultList for all list-specific tools.',
+  "Item-changing tools update the user's live Bring! account. Respect the tool annotations and confirm destructive actions when the client requires it.",
+].join(' ');
+
+export function createBringServer(bc: BringService, version = readPackageVersion()): McpServer {
+  const server = new McpServer(
+    {
+      name: 'bring-mcp',
+      title: 'Bring! Shopping Lists',
+      version,
+      description: 'Read and update Bring! shopping lists through the unofficial Bring! API.',
+      websiteUrl: 'https://github.com/florianwittkamp/bring-mcp',
+    },
+    {
+      instructions: SERVER_INSTRUCTIONS,
+      cacheHints: {
+        'tools/list': { ttlMs: 300_000, cacheScope: 'public' },
+        'server/discover': { ttlMs: 300_000, cacheScope: 'public' },
+      },
+    },
+  );
+
+  registerListTools(server, bc);
+  registerItemTools(server, bc);
+  registerUserTools(server, bc);
+  registerCatalogTools(server, bc);
+
+  return server;
+}

--- a/src/toolAnnotations.ts
+++ b/src/toolAnnotations.ts
@@ -1,4 +1,4 @@
-import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { ToolAnnotations } from '@modelcontextprotocol/server';
 
 export const READ_ONLY_TOOL_ANNOTATIONS = {
   readOnlyHint: true,
@@ -10,6 +10,6 @@ export const READ_ONLY_TOOL_ANNOTATIONS = {
 export const MUTATING_TOOL_ANNOTATIONS = {
   readOnlyHint: false,
   destructiveHint: true,
-  idempotentHint: false,
+  idempotentHint: true,
   openWorldHint: true,
 } satisfies ToolAnnotations;

--- a/src/toolSchemas.ts
+++ b/src/toolSchemas.ts
@@ -1,0 +1,134 @@
+import { z } from 'zod';
+
+export const shoppingListSchema = z.object({
+  listUuid: z.string().describe('Unique identifier of the shopping list.'),
+  name: z.string().describe('Display name of the shopping list.'),
+  theme: z.string().optional().describe('Bring! theme assigned to the shopping list.'),
+});
+
+export const loadListsOutputSchema = z.object({
+  lists: z.array(shoppingListSchema),
+});
+
+export const shoppingItemSchema = z.object({
+  name: z.string(),
+  specification: z.string().nullable(),
+  itemId: z.string().describe('Identifier accepted by item mutation tools.'),
+});
+
+export const getItemsOutputSchema = z.object({
+  uuid: z.string(),
+  status: z.string(),
+  purchase: z.array(shoppingItemSchema),
+  recently: z.array(shoppingItemSchema),
+});
+
+export const itemDetailsSchema = z.object({
+  uuid: z.string(),
+  itemId: z.string(),
+  listUuid: z.string(),
+  userIconItemId: z.string(),
+  userSectionId: z.string(),
+  assignedTo: z.string(),
+  imageUrl: z.string(),
+});
+
+export const getItemsDetailsOutputSchema = z.array(itemDetailsSchema);
+
+export const saveItemOutputSchema = z.object({
+  success: z.literal(true),
+  listUuid: z.string(),
+  itemName: z.string(),
+  specification: z.string().nullable(),
+});
+
+export const saveItemBatchOutputSchema = z.object({
+  success: z.literal(true),
+  listUuid: z.string(),
+  count: z.number().int().nonnegative(),
+  items: z.array(
+    z.object({
+      itemName: z.string(),
+      specification: z.string().nullable(),
+    }),
+  ),
+});
+
+export const itemMutationOutputSchema = z.object({
+  success: z.literal(true),
+  listUuid: z.string(),
+  itemId: z.string(),
+});
+
+export const imageMutationOutputSchema = z.object({
+  success: z.literal(true),
+  itemId: z.string(),
+  imageUrl: z.string().optional(),
+});
+
+export const deleteMultipleItemsOutputSchema = z.object({
+  success: z.literal(true),
+  listUuid: z.string(),
+  count: z.number().int().nonnegative(),
+  itemNames: z.array(z.string()),
+});
+
+export const listUserSchema = z.object({
+  publicUuid: z.string(),
+  name: z.string(),
+  email: z.string(),
+  photoPath: z.string(),
+  pushEnabled: z.boolean(),
+  plusTryOut: z.boolean(),
+  country: z.string(),
+  language: z.string(),
+});
+
+export const getAllUsersOutputSchema = z.object({
+  users: z.array(listUserSchema),
+});
+
+export const settingSchema = z.object({
+  key: z.string(),
+  value: z.string(),
+});
+
+export const getUserSettingsOutputSchema = z.object({
+  settings: z.array(settingSchema),
+  listSettings: z.array(
+    z.object({
+      listUuid: z.string(),
+      settings: z.array(settingSchema),
+    }),
+  ),
+});
+
+export const getPendingInvitationsOutputSchema = z.object({
+  invitations: z.array(z.unknown()),
+});
+
+export const getDefaultListOutputSchema = z.object({
+  listUuid: z.string().nullable(),
+  source: z.enum(['configured', 'only-list', 'not-configured']),
+  message: z.string().optional(),
+});
+
+export const translationsOutputSchema = z.record(z.string(), z.string());
+
+export const catalogItemSchema = z.object({
+  itemId: z.string(),
+  name: z.string(),
+});
+
+export const catalogSectionSchema = z.object({
+  sectionId: z.string(),
+  name: z.string(),
+  items: z.array(catalogItemSchema),
+});
+
+export const catalogOutputSchema = z.object({
+  language: z.string(),
+  catalog: z.object({
+    sections: z.array(catalogSectionSchema),
+  }),
+});

--- a/src/tools/catalogTools.ts
+++ b/src/tools/catalogTools.ts
@@ -1,10 +1,11 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
-import { BringClient } from '../bringClient.js';
-import { registerTool } from '../index.js';
+import type { BringService } from '../bringClient.js';
+import { registerTool } from '../registerTool.js';
 import { READ_ONLY_TOOL_ANNOTATIONS } from '../toolAnnotations.js';
+import { catalogOutputSchema, translationsOutputSchema } from '../toolSchemas.js';
 
-export function registerCatalogTools(server: McpServer, bc: BringClient) {
+export function registerCatalogTools(server: McpServer, bc: BringService) {
   const loadTranslationsParams = z.object({
     locale: z
       .string()
@@ -15,10 +16,12 @@ export function registerCatalogTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'loadTranslations',
+    title: 'Load Bring! Translations',
     description:
       "Load translations for item names and other UI elements. Optionally specify a locale (e.g., 'de-DE', 'en-US'). Defaults to 'en-US'.",
-    schemaShape: loadTranslationsParams.shape,
-    actionFn: async (args: z.infer<typeof loadTranslationsParams>, bc: BringClient) => bc.loadTranslations(args.locale),
+    inputSchema: loadTranslationsParams,
+    outputSchema: translationsOutputSchema,
+    actionFn: async (args, bc) => translationsOutputSchema.parse(await bc.loadTranslations(args.locale)),
     failureMessage: 'Failed to load translations',
     annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
@@ -30,9 +33,11 @@ export function registerCatalogTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'loadCatalog',
+    title: 'Load Bring! Catalog',
     description: 'Load the Bring! catalog for a specific locale. This contains standard items.',
-    schemaShape: loadCatalogParams.shape,
-    actionFn: async (args: z.infer<typeof loadCatalogParams>, bc: BringClient) => bc.loadCatalog(args.locale),
+    inputSchema: loadCatalogParams,
+    outputSchema: catalogOutputSchema,
+    actionFn: async (args, bc) => catalogOutputSchema.parse(await bc.loadCatalog(args.locale)),
     failureMessage: 'Failed to load catalog',
     annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });

--- a/src/tools/itemTools.ts
+++ b/src/tools/itemTools.ts
@@ -1,7 +1,7 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
-import { BringClient } from '../bringClient.js';
-import { registerTool } from '../index.js';
+import type { BringService } from '../bringClient.js';
+import { registerTool } from '../registerTool.js';
 import {
   listUuidParam,
   itemIdParam,
@@ -12,8 +12,17 @@ import {
   itemNamesArrayParam,
 } from '../schemaShared.js';
 import { MUTATING_TOOL_ANNOTATIONS, READ_ONLY_TOOL_ANNOTATIONS } from '../toolAnnotations.js';
+import {
+  deleteMultipleItemsOutputSchema,
+  getItemsDetailsOutputSchema,
+  getItemsOutputSchema,
+  imageMutationOutputSchema,
+  itemMutationOutputSchema,
+  saveItemBatchOutputSchema,
+  saveItemOutputSchema,
+} from '../toolSchemas.js';
 
-export function registerItemTools(server: McpServer, bc: BringClient) {
+export function registerItemTools(server: McpServer, bc: BringService) {
   const getItemsParams = z.object({
     ...listUuidParam,
   });
@@ -21,9 +30,11 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'getItems',
+    title: 'Get Shopping List Items',
     description: 'Get all items from a specific shopping list.',
-    schemaShape: getItemsParams.shape,
-    actionFn: async (args: z.infer<typeof getItemsParams>, bc: BringClient) => bc.getItems(args.listUuid),
+    inputSchema: getItemsParams,
+    outputSchema: getItemsOutputSchema,
+    actionFn: async (args, bc) => getItemsOutputSchema.parse(await bc.getItems(args.listUuid)),
     failureMessage: 'Failed to get items',
     annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
@@ -35,9 +46,11 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'getItemsDetails',
-    description: 'Get details for items in a list. (Take listUuid)',
-    schemaShape: getItemsDetailsParams.shape,
-    actionFn: async (args: z.infer<typeof getItemsDetailsParams>, bc: BringClient) => bc.getItemsDetails(args.listUuid),
+    title: 'Get Shopping Item Details',
+    description: 'Get detailed item metadata for a shopping list.',
+    inputSchema: getItemsDetailsParams,
+    outputSchema: getItemsDetailsOutputSchema,
+    actionFn: async (args, bc) => getItemsDetailsOutputSchema.parse(await bc.getItemsDetails(args.listUuid)),
     failureMessage: 'Failed to get item details',
     annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
@@ -46,15 +59,20 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'saveItem',
+    title: 'Add or Update Shopping Item',
     description:
       'Save an item to a shopping list. Use the "specification" parameter to add details like quantity or type (e.g., itemName: "Milk", specification: "2 liters").',
-    schemaShape: { ...listUuidParam, ...itemNameParam, ...itemSpecificationParam },
-    actionFn: async (args: { listUuid: string; itemName: string; specification?: string | null }, bc) => {
-      return bc.saveItem(args.listUuid, args.itemName, args.specification);
+    inputSchema: z.object({ ...listUuidParam, ...itemNameParam, ...itemSpecificationParam }),
+    outputSchema: saveItemOutputSchema,
+    actionFn: async (args, bc) => {
+      await bc.saveItem(args.listUuid, args.itemName, args.specification);
+      return saveItemOutputSchema.parse({
+        success: true,
+        listUuid: args.listUuid,
+        itemName: args.itemName,
+        specification: args.specification ?? null,
+      });
     },
-    transformResult: (result: unknown) => ({
-      content: [{ type: 'text', text: `Item saved: ${JSON.stringify(result)}` }],
-    }),
     failureMessage: 'Failed to save item',
     annotations: MUTATING_TOOL_ANNOTATIONS,
   });
@@ -63,15 +81,23 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'saveItemBatch',
+    title: 'Add or Update Multiple Shopping Items',
     description:
       'Save multiple items to a shopping list. For each item, you can provide an "itemName" and an optional "specification" for details like quantity or type (input e.g., [{ "itemName": "Eggs", "specification": "dozen" },{ "itemName":"Apples", "specification": "10" }]).',
-    schemaShape: saveItemBatchParams,
-    actionFn: async (args: { listUuid: string; items: { itemName: string; specification?: string | null }[] }, bc) => {
-      return bc.saveItemBatch(args.listUuid, args.items);
+    inputSchema: z.object(saveItemBatchParams),
+    outputSchema: saveItemBatchOutputSchema,
+    actionFn: async (args, bc) => {
+      await bc.saveItemBatch(args.listUuid, args.items);
+      return saveItemBatchOutputSchema.parse({
+        success: true,
+        listUuid: args.listUuid,
+        count: args.items.length,
+        items: args.items.map((item) => ({
+          itemName: item.itemName,
+          specification: item.specification ?? null,
+        })),
+      });
     },
-    transformResult: (result: unknown) => ({
-      content: [{ type: 'text', text: `Batch items saved: ${JSON.stringify(result)}` }],
-    }),
     failureMessage: 'Failed to save batch items',
     annotations: MUTATING_TOOL_ANNOTATIONS,
   });
@@ -84,10 +110,14 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'removeItem',
+    title: 'Remove Shopping Item',
     description: 'Remove an item from a specific shopping list.',
-    schemaShape: removeItemParams.shape,
-    actionFn: async (args: z.infer<typeof removeItemParams>, bc: BringClient) =>
-      bc.removeItem(args.listUuid, args.itemId),
+    inputSchema: removeItemParams,
+    outputSchema: itemMutationOutputSchema,
+    actionFn: async (args, bc) => {
+      await bc.removeItem(args.listUuid, args.itemId);
+      return itemMutationOutputSchema.parse({ success: true, listUuid: args.listUuid, itemId: args.itemId });
+    },
     failureMessage: 'Failed to remove item',
     annotations: MUTATING_TOOL_ANNOTATIONS,
   });
@@ -100,10 +130,14 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'moveToRecentList',
+    title: 'Move Item to Recently Used',
     description: 'Move an item from a shopping list to the recently used items list.',
-    schemaShape: moveToRecentListParams.shape,
-    actionFn: async (args: z.infer<typeof moveToRecentListParams>, bc: BringClient) =>
-      bc.moveToRecentList(args.listUuid, args.itemId),
+    inputSchema: moveToRecentListParams,
+    outputSchema: itemMutationOutputSchema,
+    actionFn: async (args, bc) => {
+      await bc.moveToRecentList(args.listUuid, args.itemId);
+      return itemMutationOutputSchema.parse({ success: true, listUuid: args.listUuid, itemId: args.itemId });
+    },
     failureMessage: 'Failed to move item to recent list',
     annotations: MUTATING_TOOL_ANNOTATIONS,
   });
@@ -116,10 +150,18 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'saveItemImage',
+    title: 'Save Shopping Item Image',
     description: 'Save an image for an item. Provide the image as base64-encoded data (maximum decoded size: 5 MiB).',
-    schemaShape: saveItemImageParams.shape,
-    actionFn: async (args: z.infer<typeof saveItemImageParams>, bc: BringClient) =>
-      bc.saveItemImage(args.itemId, args.imageData),
+    inputSchema: saveItemImageParams,
+    outputSchema: imageMutationOutputSchema,
+    actionFn: async (args, bc) => {
+      const response = await bc.saveItemImage(args.itemId, args.imageData);
+      const imageUrl =
+        response && typeof response === 'object' && 'imageUrl' in response && typeof response.imageUrl === 'string'
+          ? response.imageUrl
+          : undefined;
+      return imageMutationOutputSchema.parse({ success: true, itemId: args.itemId, imageUrl });
+    },
     failureMessage: 'Failed to save item image',
     annotations: MUTATING_TOOL_ANNOTATIONS,
   });
@@ -131,9 +173,14 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'removeItemImage',
+    title: 'Remove Shopping Item Image',
     description: 'Remove an image from an item on a shopping list.',
-    schemaShape: removeItemImageParams.shape,
-    actionFn: async (args: z.infer<typeof removeItemImageParams>, bc: BringClient) => bc.removeItemImage(args.itemId),
+    inputSchema: removeItemImageParams,
+    outputSchema: imageMutationOutputSchema,
+    actionFn: async (args, bc) => {
+      await bc.removeItemImage(args.itemId);
+      return imageMutationOutputSchema.parse({ success: true, itemId: args.itemId });
+    },
     failureMessage: 'Failed to remove item image',
     annotations: MUTATING_TOOL_ANNOTATIONS,
   });
@@ -146,13 +193,19 @@ export function registerItemTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'deleteMultipleItemsFromList',
+    title: 'Delete Multiple Shopping Items',
     description: 'Delete multiple items from a specific shopping list by their names.',
-    schemaShape: deleteMultipleItemsParams.shape,
-    actionFn: async (args: z.infer<typeof deleteMultipleItemsParams>, bc: BringClient) =>
-      bc.deleteMultipleItemsFromList(args.listUuid, args.itemNames),
-    transformResult: (result: unknown) => ({
-      content: [{ type: 'text', text: `Multiple items deleted: ${JSON.stringify(result)}` }],
-    }),
+    inputSchema: deleteMultipleItemsParams,
+    outputSchema: deleteMultipleItemsOutputSchema,
+    actionFn: async (args, bc) => {
+      await bc.deleteMultipleItemsFromList(args.listUuid, args.itemNames);
+      return deleteMultipleItemsOutputSchema.parse({
+        success: true,
+        listUuid: args.listUuid,
+        count: args.itemNames.length,
+        itemNames: args.itemNames,
+      });
+    },
     failureMessage: 'Failed to delete multiple items',
     annotations: MUTATING_TOOL_ANNOTATIONS,
   });

--- a/src/tools/listTools.ts
+++ b/src/tools/listTools.ts
@@ -1,20 +1,21 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-// import { z } from 'zod'; // Removed as z is unused
-import { BringClient } from '../bringClient.js';
-import { registerTool } from '../index.js'; // Assuming registerTool will be exported from index.ts
+import { McpServer } from '@modelcontextprotocol/server';
+import type { BringService } from '../bringClient.js';
+import { registerTool } from '../registerTool.js';
+import { noArgsSchema } from '../schemaShared.js';
 import { READ_ONLY_TOOL_ANNOTATIONS } from '../toolAnnotations.js';
+import { loadListsOutputSchema } from '../toolSchemas.js';
 
-export function registerListTools(server: McpServer, bc: BringClient) {
+export function registerListTools(server: McpServer, bc: BringService) {
   registerTool({
     server,
     bc,
     name: 'loadLists',
+    title: 'Load Shopping Lists',
     description: 'Load all shopping lists from Bring!',
-    schemaShape: undefined, // Explicitly undefined for no-args tool
-    actionFn: async (_args: undefined, bc: BringClient) => bc.loadLists(),
+    inputSchema: noArgsSchema,
+    outputSchema: loadListsOutputSchema,
+    actionFn: async (_args, bc) => loadListsOutputSchema.parse(await bc.loadLists()),
     failureMessage: 'Failed to load lists',
     annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
-
-  // Add other list-related tools here if any in the future
 }

--- a/src/tools/userTools.ts
+++ b/src/tools/userTools.ts
@@ -1,11 +1,54 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
-import { BringClient } from '../bringClient.js';
-import { registerTool } from '../index.js';
-import { listUuidParam } from '../schemaShared.js';
+import type { BringService } from '../bringClient.js';
+import { registerTool } from '../registerTool.js';
+import { listUuidParam, noArgsSchema } from '../schemaShared.js';
 import { READ_ONLY_TOOL_ANNOTATIONS } from '../toolAnnotations.js';
+import {
+  getAllUsersOutputSchema,
+  getDefaultListOutputSchema,
+  getPendingInvitationsOutputSchema,
+  getUserSettingsOutputSchema,
+  loadListsOutputSchema,
+  settingSchema,
+} from '../toolSchemas.js';
 
-export function registerUserTools(server: McpServer, bc: BringClient) {
+type Setting = z.infer<typeof settingSchema>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeSettings(value: unknown): Setting[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    const parsed = settingSchema.safeParse(entry);
+    return parsed.success ? [parsed.data] : [];
+  });
+}
+
+export function normalizeUserSettings(value: unknown): z.infer<typeof getUserSettingsOutputSchema> {
+  const source = isRecord(value) ? value : {};
+  const rawListSettings = source.userlistsettings ?? source.userListSettings;
+  const listSettings = Array.isArray(rawListSettings)
+    ? rawListSettings.flatMap((entry) => {
+        if (!isRecord(entry) || typeof entry.listUuid !== 'string') return [];
+        return [
+          {
+            listUuid: entry.listUuid,
+            settings: normalizeSettings(entry.usersettings ?? entry.userSettings ?? entry.settings),
+          },
+        ];
+      })
+    : [];
+
+  return getUserSettingsOutputSchema.parse({
+    settings: normalizeSettings(source.usersettings ?? source.userSettings ?? source.settings),
+    listSettings,
+  });
+}
+
+export function registerUserTools(server: McpServer, bc: BringService) {
   const getAllUsersFromListParams = z.object({
     ...listUuidParam,
   });
@@ -13,10 +56,11 @@ export function registerUserTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'getAllUsersFromList',
+    title: 'Get Shopping List Users',
     description: 'Get all users associated with a specific shopping list.',
-    schemaShape: getAllUsersFromListParams.shape,
-    actionFn: async (args: z.infer<typeof getAllUsersFromListParams>, bc: BringClient) =>
-      bc.getAllUsersFromList(args.listUuid),
+    inputSchema: getAllUsersFromListParams,
+    outputSchema: getAllUsersOutputSchema,
+    actionFn: async (args, bc) => getAllUsersOutputSchema.parse(await bc.getAllUsersFromList(args.listUuid)),
     failureMessage: 'Failed to get all users from list',
     annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
@@ -25,9 +69,11 @@ export function registerUserTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'getUserSettings',
+    title: 'Get Bring! User Settings',
     description: 'Get the settings for the current authenticated user.',
-    schemaShape: undefined,
-    actionFn: async (_args: undefined, bc: BringClient) => bc.getUserSettings(),
+    inputSchema: noArgsSchema,
+    outputSchema: getUserSettingsOutputSchema,
+    actionFn: async (_args, bc) => normalizeUserSettings(await bc.getUserSettings()),
     failureMessage: 'Failed to get user settings',
     annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
@@ -36,9 +82,11 @@ export function registerUserTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'getPendingInvitations',
+    title: 'Get Pending Shopping List Invitations',
     description: 'Get any pending invitations for the authenticated user to join shopping lists.',
-    schemaShape: undefined,
-    actionFn: async (_args: undefined, bc: BringClient) => bc.getPendingInvitations(),
+    inputSchema: noArgsSchema,
+    outputSchema: getPendingInvitationsOutputSchema,
+    actionFn: async (_args, bc) => getPendingInvitationsOutputSchema.parse(await bc.getPendingInvitations()),
     failureMessage: 'Failed to get pending invitations',
     annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
@@ -47,35 +95,40 @@ export function registerUserTools(server: McpServer, bc: BringClient) {
     server,
     bc,
     name: 'getDefaultList',
+    title: 'Get Default Shopping List',
     description:
       'Get the UUID of the default shopping list for the authenticated user. Use this if the user does not ask for a special list.',
-    schemaShape: undefined,
-    actionFn: async (_args: undefined, bc: BringClient) => {
-      const settings = await bc.getUserSettings();
-      // @ts-expect-error The bring-shopping type GetUserSettingsResponse may be outdated
-      // and not include usersettings array structure, which is expected based on API observation.
-      if (settings && settings.usersettings && Array.isArray(settings.usersettings)) {
-        // @ts-expect-error The bring-shopping type GetUserSettingsResponse may be outdated.
-        const defaultListSetting = settings.usersettings.find(
-          (setting: { key: string; value: string }) => setting.key === 'defaultListUUID',
-        );
-        if (defaultListSetting) {
-          return defaultListSetting.value;
-        }
+    inputSchema: noArgsSchema,
+    outputSchema: getDefaultListOutputSchema,
+    actionFn: async (_args, bc) => {
+      const settings = normalizeUserSettings(await bc.getUserSettings());
+      const defaultListSetting = [
+        ...settings.settings,
+        ...settings.listSettings.flatMap((entry) => entry.settings),
+      ].find((setting) => setting.key === 'defaultListUUID');
+      if (defaultListSetting) {
+        return getDefaultListOutputSchema.parse({
+          listUuid: defaultListSetting.value,
+          source: 'configured',
+        });
       }
 
-      const listsResponse = await bc.loadLists();
-      const lists = listsResponse?.lists;
+      const listsResponse = loadListsOutputSchema.parse(await bc.loadLists());
+      const lists = listsResponse.lists;
       if (Array.isArray(lists) && lists.length === 1 && lists[0]?.listUuid) {
-        return lists[0].listUuid;
+        return getDefaultListOutputSchema.parse({
+          listUuid: lists[0].listUuid,
+          source: 'only-list',
+        });
       }
 
-      return 'No default list is configured. Set one in the Bring app, or call loadLists to choose.';
+      return getDefaultListOutputSchema.parse({
+        listUuid: null,
+        source: 'not-configured',
+        message: 'No default list is configured. Set one in the Bring app, or call loadLists to choose.',
+      });
     },
     failureMessage: 'Failed to get default list UUID',
-    transformResult: (result: string) => ({
-      content: [{ type: 'text', text: result }],
-    }),
     annotations: READ_ONLY_TOOL_ANNOTATIONS,
   });
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,242 +1,111 @@
 /// <reference types="jest" />
 
-// tests/helpers.ts
-import { jest } from '@jest/globals'; // Import jest globals
-// import type { McpServer, StdioServerTransport } from '@modelcontextprotocol/sdk'; // Commenting out for now
-// import type { BringClient } from '../src/bringClient'; // Removed unused import
+import { jest } from '@jest/globals';
+import type { BringService } from '../src/bringClient.js';
 
-// Mock functions for BringClient methods
-export let mockLogin: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockLoadLists: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockGetItems: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockGetItemsDetails: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockSaveItem: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockSaveItemBatch: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockRemoveItem: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockMoveToRecentList: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockSaveItemImage: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockRemoveItemImage: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockGetAllUsersFromList: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockGetUserSettings: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockLoadTranslations: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockLoadCatalog: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockGetPendingInvitations: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-export let mockDeleteMultipleItemsFromList: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
+type AsyncMock = jest.MockedFunction<(...args: never[]) => Promise<unknown>>;
 
-// --- Mock for StdioServerTransport ---
-export const mockStdioServerTransportInstance = {
-  // Potentially mock methods like .on, .send if used by McpServer.connect
-  // For now, it's an empty object, assuming McpServer.connect itself is what we are testing mostly.
-};
+export const mockLoadLists = jest.fn() as AsyncMock;
+export const mockGetItems = jest.fn() as AsyncMock;
+export const mockGetItemsDetails = jest.fn() as AsyncMock;
+export const mockSaveItem = jest.fn() as AsyncMock;
+export const mockSaveItemBatch = jest.fn() as AsyncMock;
+export const mockRemoveItem = jest.fn() as AsyncMock;
+export const mockMoveToRecentList = jest.fn() as AsyncMock;
+export const mockSaveItemImage = jest.fn() as AsyncMock;
+export const mockRemoveItemImage = jest.fn() as AsyncMock;
+export const mockGetAllUsersFromList = jest.fn() as AsyncMock;
+export const mockGetUserSettings = jest.fn() as AsyncMock;
+export const mockLoadTranslations = jest.fn() as AsyncMock;
+export const mockLoadCatalog = jest.fn() as AsyncMock;
+export const mockGetPendingInvitations = jest.fn() as AsyncMock;
+export const mockDeleteMultipleItemsFromList = jest.fn() as AsyncMock;
 
-jest.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
-  StdioServerTransport: jest.fn(() => mockStdioServerTransportInstance), // Ensure this mock is used
-}));
-
-jest.mock('../src/bringClient.js', () => {
-  mockLogin = jest.fn();
-  mockLoadLists = jest.fn();
-  mockGetItems = jest.fn();
-  mockGetItemsDetails = jest.fn();
-  mockSaveItem = jest.fn();
-  mockSaveItemBatch = jest.fn();
-  mockRemoveItem = jest.fn();
-  mockMoveToRecentList = jest.fn();
-  mockSaveItemImage = jest.fn();
-  mockRemoveItemImage = jest.fn();
-  mockGetAllUsersFromList = jest.fn();
-  mockGetUserSettings = jest.fn();
-  mockLoadTranslations = jest.fn();
-  mockLoadCatalog = jest.fn();
-  mockGetPendingInvitations = jest.fn();
-  mockDeleteMultipleItemsFromList = jest.fn();
-
-  return {
-    BringClient: jest.fn().mockImplementation(() => ({
-      loadLists: mockLoadLists,
-      getItems: mockGetItems,
-      getItemsDetails: mockGetItemsDetails,
-      saveItem: mockSaveItem,
-      saveItemBatch: mockSaveItemBatch,
-      removeItem: mockRemoveItem,
-      moveToRecentList: mockMoveToRecentList,
-      saveItemImage: mockSaveItemImage,
-      removeItemImage: mockRemoveItemImage,
-      getAllUsersFromList: mockGetAllUsersFromList,
-      getUserSettings: mockGetUserSettings,
-      loadTranslations: mockLoadTranslations,
-      loadCatalog: mockLoadCatalog,
-      getPendingInvitations: mockGetPendingInvitations,
-      deleteMultipleItemsFromList: mockDeleteMultipleItemsFromList,
-    })),
-    connect: jest.fn(),
-    listen: jest.fn(), // Adding listen as it might be called by connect
-  };
-});
-
-export interface McpTool {
-  description: string;
-  schema: Record<string, unknown>;
-  outputSchema: Record<string, unknown>;
-  annotations: Record<string, unknown>;
-  callback: (...args: Record<string, unknown>[]) => Promise<{
-    content: { type: string; text: string }[];
-    structuredContent?: Record<string, unknown>;
-    isError?: boolean;
-  }>;
+export interface McpToolResult {
+  content: { type: string; text: string }[];
+  structuredContent?: unknown;
+  isError?: boolean;
 }
 
-export const mockTools: Map<string, McpTool> = new Map();
+interface ZodObjectLike {
+  shape?: Record<string, unknown>;
+}
+
+export interface McpTool {
+  title: string;
+  description: string;
+  schema: Record<string, unknown>;
+  inputSchema: unknown;
+  outputSchema: unknown;
+  annotations: Record<string, unknown>;
+  callback: (args: Record<string, unknown>) => Promise<McpToolResult>;
+}
+
+export const mockTools = new Map<string, McpTool>();
 
 export const mockMcpServerInstance = {
   registerTool: jest.fn(
     (
       name: string,
       config: {
+        title?: string;
         description?: string;
-        inputSchema?: Record<string, unknown>;
-        outputSchema?: Record<string, unknown>;
+        inputSchema?: ZodObjectLike;
+        outputSchema?: unknown;
         annotations?: Record<string, unknown>;
       },
-      callback: (...args: Record<string, unknown>[]) => Promise<{
-        content: { type: string; text: string }[];
-        structuredContent?: Record<string, unknown>;
-        isError?: boolean;
-      }>,
+      callback: (args: Record<string, unknown>) => Promise<McpToolResult>,
     ) => {
       mockTools.set(name, {
+        title: config.title ?? '',
         description: config.description ?? '',
-        schema: config.inputSchema ?? {},
-        outputSchema: config.outputSchema ?? {},
+        schema: config.inputSchema?.shape ?? {},
+        inputSchema: config.inputSchema,
+        outputSchema: config.outputSchema,
         annotations: config.annotations ?? {},
         callback,
       });
     },
   ),
-  connect: jest.fn<() => Promise<void>>(),
-  listen: jest.fn(),
 };
 
-jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
-  McpServer: jest.fn(() => mockMcpServerInstance),
+export const mockMcpServerConstructor = jest.fn(() => mockMcpServerInstance);
+export const mockServeStdio = jest.fn();
+
+jest.mock('@modelcontextprotocol/server', () => ({
+  McpServer: mockMcpServerConstructor,
+}));
+
+jest.mock('@modelcontextprotocol/server/stdio', () => ({
+  serveStdio: mockServeStdio,
 }));
 
 jest.mock('dotenv/config', () => ({}));
 
-export async function loadServer() {
+const mockBringService = {
+  loadLists: mockLoadLists,
+  getItems: mockGetItems,
+  getItemsDetails: mockGetItemsDetails,
+  saveItem: mockSaveItem,
+  saveItemBatch: mockSaveItemBatch,
+  removeItem: mockRemoveItem,
+  moveToRecentList: mockMoveToRecentList,
+  saveItemImage: mockSaveItemImage,
+  removeItemImage: mockRemoveItemImage,
+  getAllUsersFromList: mockGetAllUsersFromList,
+  getUserSettings: mockGetUserSettings,
+  loadTranslations: mockLoadTranslations,
+  loadCatalog: mockLoadCatalog,
+  getPendingInvitations: mockGetPendingInvitations,
+  deleteMultipleItemsFromList: mockDeleteMultipleItemsFromList,
+};
+
+export async function loadServer(): Promise<void> {
   jest.resetModules();
-  process.env.BRING_EMAIL = 'test@example.com';
-  process.env.BRING_PASSWORD = 'testpassword';
-  await import('../src/index.js');
+  const { createBringServer } = await import('../src/server.js');
+  createBringServer(mockBringService as unknown as BringService, 'test-version');
 }
 
 export function getTool(name: string): McpTool | undefined {
   return mockTools.get(name);
 }
-
-// Ensure all mock variables are exported correctly
-// ... existing code ...
-// Keep track of mock functions for BringClient methods
-// export let mockLogin: jest.Mock;
-// export let mockLoadLists: jest.Mock;
-// export let mockGetItems: jest.Mock;
-// export let mockGetItemsDetails: jest.Mock;
-// export let mockSaveItem: jest.Mock;
-// export let mockRemoveItem: jest.Mock;
-// export let mockMoveToRecentList: jest.Mock;
-// export let mockSaveItemImage: jest.Mock;
-// export let mockRemoveItemImage: jest.Mock;
-// export let mockGetAllUsersFromList: jest.Mock;
-// export let mockGetUserSettings: jest.Mock;
-// export let mockLoadTranslations: jest.Mock;
-// export let mockLoadCatalog: jest.Mock;
-// export let mockGetPendingInvitations: jest.Mock;
-
-// jest.mock('../src/bringClient.js', () => {
-//   mockLogin = jest.fn();
-//   mockLoadLists = jest.fn();
-//   mockGetItems = jest.fn();
-//   mockGetItemsDetails = jest.fn();
-//   mockSaveItem = jest.fn();
-//   mockRemoveItem = jest.fn();
-//   mockMoveToRecentList = jest.fn();
-//   mockSaveItemImage = jest.fn();
-//   mockRemoveItemImage = jest.fn();
-//   mockGetAllUsersFromList = jest.fn();
-//   mockGetUserSettings = jest.fn();
-//   mockLoadTranslations = jest.fn();
-//   mockLoadCatalog = jest.fn();
-//   mockGetPendingInvitations = jest.fn();
-
-//   return {
-//     BringClient: jest.fn().mockImplementation(() => ({
-//       login: mockLogin,
-//       loadLists: mockLoadLists,
-//       getItems: mockGetItems,
-//       getItemsDetails: mockGetItemsDetails,
-//       saveItem: mockSaveItem,
-//       removeItem: mockRemoveItem,
-//       moveToRecentList: mockMoveToRecentList,
-//       saveItemImage: mockSaveItemImage,
-//       removeItemImage: mockRemoveItemImage,
-//       getAllUsersFromList: mockGetAllUsersFromList,
-//       getUserSettings: mockGetUserSettings,
-//       loadTranslations: mockLoadTranslations,
-//       loadCatalog: mockLoadCatalog,
-//       getPendingInvitations: mockGetPendingInvitations,
-//     })),
-//   };
-// });
-
-// // --- Mocking McpServer ---
-// export const mockTools: Map<
-//   string,
-//   {
-//     description: string;
-//     schema: Record<string, unknown>;
-//     callback: (...args: Record<string, unknown>[]) => Promise<Record<string, unknown>>;
-//   }
-// > = new Map();
-
-// export const mockMcpServerInstance = {
-//   tool: jest.fn((name, description, schema, callback) => {
-//     mockTools.set(name, { description, schema, callback });
-//   }),
-//   connect: jest.fn(),
-//   // Add any other methods of McpServer that are used if necessary
-// };
-
-// jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
-//   McpServer: jest.fn(() => mockMcpServerInstance),
-// }));
-
-// // --- Mocking StdioServerTransport ---
-// jest.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
-//   StdioServerTransport: jest.fn(() => ({})),
-// }));
-
-// // --- Mocking dotenv ---
-// jest.mock('dotenv/config', () => ({})); // This will mock the side-effect import
-
-// // --- Test Setup ---
-// export async function loadServer() {
-//   jest.resetModules(); // Reset modules to ensure index.ts is re-evaluated
-
-//   // Set up process.env before index.ts is loaded
-//   process.env.BRING_EMAIL = 'test@example.com';
-//   process.env.BRING_PASSWORD = 'testpassword';
-
-//   // Dynamically import index.ts AFTER mocks are set up
-//   // The path to index.js needs to be relative to this helpers.ts file,
-//   // or an absolute path, or use module path aliases if configured
-//   await import('../src/index.js'); // Adjusted path, assuming index.js is in src/
-// }
-
-// // Utility to get a registered tool (optional, but can be handy)
-// export function getTool(name: string) {
-//   const tool = mockTools.get(name);
-//   if (!tool) {
-//     throw new Error(`Tool "${name}" not found. Make sure it was registered.`);
-//   }
-//   return tool;
-// }

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -1,133 +1,73 @@
-import {
-  mockSaveItemImage,
-  mockRemoveItemImage,
-  mockMcpServerInstance,
-  mockTools,
-  loadServer,
-  getTool,
-} from './helpers';
 import { itemImageDataParam } from '../src/schemaShared';
+import { getTool, loadServer, mockRemoveItemImage, mockSaveItemImage, mockTools } from './helpers';
 
-let consoleErrorSpy: jest.SpyInstance;
+describe('image tools', () => {
+  let consoleErrorSpy: jest.SpyInstance;
 
-describe('MCP Bring! Server - Image Tools', () => {
   beforeEach(async () => {
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     jest.clearAllMocks();
     mockTools.clear();
     await loadServer();
   });
 
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
+  afterEach(() => consoleErrorSpy.mockRestore());
+
+  it('rejects local paths and image data larger than 5 MiB', () => {
+    expect(itemImageDataParam.imageData.safeParse('/path/to/image.jpg').success).toBe(false);
+    expect(itemImageDataParam.imageData.safeParse('aW1hZ2U=').success).toBe(true);
+    expect(itemImageDataParam.imageData.safeParse('A'.repeat(6_990_512)).success).toBe(false);
   });
 
-  describe('bring.saveItemImage tool', () => {
-    it('rejects local paths and image data larger than 5 MiB', () => {
-      expect(itemImageDataParam.imageData.safeParse('/path/to/image.jpg').success).toBe(false);
-      expect(itemImageDataParam.imageData.safeParse('aW1hZ2U=').success).toBe(true);
-      expect(itemImageDataParam.imageData.safeParse('A'.repeat(6_990_512)).success).toBe(false);
+  it('registers both mutations with complete metadata', () => {
+    expect(getTool('saveItemImage')).toMatchObject({
+      title: 'Save Shopping Item Image',
+      schema: { itemId: expect.anything(), imageData: expect.anything() },
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
     });
-
-    it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'saveItemImage',
-        expect.objectContaining({
-          description:
-            'Save an image for an item. Provide the image as base64-encoded data (maximum decoded size: 5 MiB).',
-          inputSchema: expect.objectContaining({
-            itemId: expect.anything(),
-            imageData: expect.anything(),
-          }),
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
-        }),
-        expect.any(Function),
-      );
-      const tool = getTool('saveItemImage');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe(
-        'Save an image for an item. Provide the image as base64-encoded data (maximum decoded size: 5 MiB).',
-      );
-      expect(tool?.schema).toMatchObject({ itemId: {}, imageData: {} });
-      expect(tool?.annotations).toMatchObject({ readOnlyHint: false, destructiveHint: true });
-    });
-
-    it('should call BringClient.saveItemImage and return success', async () => {
-      const fakeItemId = 'item-img';
-      const fakeImageData = 'aW1hZ2U=';
-      const successResponse = { message: 'Image saved successfully' };
-      mockSaveItemImage.mockResolvedValue(successResponse);
-      const tool = getTool('saveItemImage');
-      if (!tool) throw new Error('Tool saveItemImage not found');
-      const result = await tool.callback({ itemId: fakeItemId, imageData: fakeImageData });
-      expect(mockSaveItemImage).toHaveBeenCalledWith(fakeItemId, fakeImageData);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: JSON.stringify(successResponse, null, 2) }],
-        structuredContent: { result: successResponse },
-      });
-    });
-
-    it('should return an error message on failed saveItemImage', async () => {
-      const fakeItemId = 'item-img';
-      const fakeImageData = 'aW1hZ2U=';
-      const errorMessage = 'Could not save image';
-      mockSaveItemImage.mockRejectedValue(new Error(errorMessage));
-      const tool = getTool('saveItemImage');
-      if (!tool) throw new Error('Tool saveItemImage not found');
-      const result = await tool.callback({ itemId: fakeItemId, imageData: fakeImageData });
-      expect(mockSaveItemImage).toHaveBeenCalledWith(fakeItemId, fakeImageData);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to save item image: ${errorMessage}` }],
-        isError: true,
-      });
+    expect(getTool('removeItemImage')).toMatchObject({
+      title: 'Remove Shopping Item Image',
+      schema: { itemId: expect.anything() },
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
     });
   });
 
-  describe('bring.removeItemImage tool', () => {
-    it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'removeItemImage',
-        expect.objectContaining({
-          description: 'Remove an image from an item on a shopping list.',
-          inputSchema: expect.objectContaining({ itemId: expect.anything() }),
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
-        }),
-        expect.any(Function),
-      );
-      const tool = getTool('removeItemImage');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe('Remove an image from an item on a shopping list.');
-      expect(tool?.schema).toMatchObject({ itemId: {} });
+  it('returns a normalized result when saving an image', async () => {
+    mockSaveItemImage.mockResolvedValue({ imageUrl: 'https://example.test/image.jpg' });
+
+    const result = await getTool('saveItemImage')!.callback({
+      itemId: 'item-img',
+      imageData: 'aW1hZ2U=',
     });
 
-    it('should call BringClient.removeItemImage and return success', async () => {
-      const fakeItemId = 'item-img-remove';
-      const successResponse = { message: 'Image removed successfully' };
-      mockRemoveItemImage.mockResolvedValue(successResponse);
-      const tool = getTool('removeItemImage');
-      if (!tool) throw new Error('Tool removeItemImage not found');
-      const result = await tool.callback({ itemId: fakeItemId });
-      expect(mockRemoveItemImage).toHaveBeenCalledWith(fakeItemId);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: JSON.stringify(successResponse, null, 2) }],
-        structuredContent: { result: successResponse },
-      });
+    expect(mockSaveItemImage).toHaveBeenCalledWith('item-img', 'aW1hZ2U=');
+    expect(result.structuredContent).toEqual({
+      success: true,
+      itemId: 'item-img',
+      imageUrl: 'https://example.test/image.jpg',
+    });
+  });
+
+  it('returns a normalized result when removing an image', async () => {
+    mockRemoveItemImage.mockResolvedValue('');
+
+    const result = await getTool('removeItemImage')!.callback({ itemId: 'item-img' });
+
+    expect(mockRemoveItemImage).toHaveBeenCalledWith('item-img');
+    expect(result.structuredContent).toEqual({ success: true, itemId: 'item-img' });
+  });
+
+  it('marks image API failures as MCP errors', async () => {
+    mockSaveItemImage.mockRejectedValue(new Error('Could not save image'));
+
+    const result = await getTool('saveItemImage')!.callback({
+      itemId: 'item-img',
+      imageData: 'aW1hZ2U=',
     });
 
-    it('should return an error message on failed removeItemImage', async () => {
-      const fakeItemId = 'item-img-remove';
-      const errorMessage = 'Could not remove image';
-      mockRemoveItemImage.mockRejectedValue(new Error(errorMessage));
-      const tool = getTool('removeItemImage');
-      if (!tool) throw new Error('Tool removeItemImage not found');
-      const result = await tool.callback({ itemId: fakeItemId });
-      expect(mockRemoveItemImage).toHaveBeenCalledWith(fakeItemId);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to remove item image: ${errorMessage}` }],
-        isError: true,
-      });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Failed to save item image: Could not save image' }],
+      isError: true,
     });
   });
 });

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -1,177 +1,136 @@
 /// <reference types="jest" />
 
 import { jest } from '@jest/globals';
-import { mockMcpServerInstance, mockStdioServerTransportInstance } from './helpers'; // Assuming StdioServerTransport is also mocked in helpers
+import { loadServer, mockMcpServerConstructor, mockMcpServerInstance, mockServeStdio, mockTools } from './helpers';
 
-// Store original process.env
-const originalEnv = process.env;
-const originalProcessExit = process.exit;
-const originalConsoleError = console.error;
+const expectedToolNames = [
+  'loadLists',
+  'getItems',
+  'getItemsDetails',
+  'saveItem',
+  'saveItemBatch',
+  'removeItem',
+  'moveToRecentList',
+  'saveItemImage',
+  'removeItemImage',
+  'deleteMultipleItemsFromList',
+  'getAllUsersFromList',
+  'getUserSettings',
+  'getPendingInvitations',
+  'getDefaultList',
+  'loadTranslations',
+  'loadCatalog',
+];
 
-describe('MCP Bring! Server - Integration Tests (Main Entry Point)', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let mockExit: any; // Using any as a last resort for SpyInstance type issue
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let mockConsoleError: any; // Using any as a last resort for SpyInstance type issue
+describe('MCP Bring! server integration', () => {
+  const originalEnvironment = process.env;
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
 
   beforeEach(() => {
-    jest.resetModules(); // Important to re-import src/index.js with fresh state
     jest.clearAllMocks();
-
-    // Restore process.env to a clone of its original state before each test
-    process.env = { ...originalEnv };
-    process.exit = originalProcessExit; // Restore original process.exit
-    console.error = originalConsoleError; // Restore original console.error
-
-    // Mock process.exit to prevent tests from terminating and to spy on it
-    mockExit = jest.spyOn(process, 'exit').mockImplementation((() => {
-      // Do nothing, effectively preventing exit
-    }) as (code?: string | number | null | undefined) => never);
-
-    // Spy on console.error
-    mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-    // Ensure mocks from helpers are clean (McpServer.connect and StdioServerTransport constructor)
-    // The mocks themselves are set up in helpers.ts
+    mockTools.clear();
+    process.env = { ...originalEnvironment };
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
-    // Restore original process.env, process.exit and console.error
-    process.env = originalEnv;
-    process.exit = originalProcessExit;
-    console.error = originalConsoleError;
-    mockExit.mockRestore();
-    mockConsoleError.mockRestore();
+    process.env = originalEnvironment;
+    consoleErrorSpy.mockRestore();
   });
 
-  it('should initialize StdioServerTransport and connect McpServer when env vars are set', async () => {
+  it('resolves current credential names and prefers them over legacy aliases', async () => {
+    const { resolveCredentials } = await import('../src/index.js');
+
+    expect(
+      resolveCredentials({
+        BRING_EMAIL: 'current@example.com',
+        BRING_PASSWORD: 'current-password',
+        MAIL: 'legacy@example.com',
+        PW: 'legacy-password',
+      }),
+    ).toEqual({
+      email: 'current@example.com',
+      password: 'current-password',
+      usesLegacyNames: false,
+    });
+  });
+
+  it('supports MAIL and PW as deprecated aliases', async () => {
+    const { resolveCredentials } = await import('../src/index.js');
+
+    expect(resolveCredentials({ MAIL: 'legacy@example.com', PW: 'legacy-password' })).toEqual({
+      email: 'legacy@example.com',
+      password: 'legacy-password',
+      usesLegacyNames: true,
+    });
+  });
+
+  it('rejects missing credentials', async () => {
+    const { resolveCredentials } = await import('../src/index.js');
+
+    expect(() => resolveCredentials({ BRING_EMAIL: 'test@example.com' })).toThrow(
+      'Missing BRING_EMAIL or BRING_PASSWORD environment variables',
+    );
+    expect(() => resolveCredentials({ BRING_PASSWORD: 'password' })).toThrow(
+      'Missing BRING_EMAIL or BRING_PASSWORD environment variables',
+    );
+  });
+
+  it('starts the v2 stdio dispatcher with legacy compatibility enabled', async () => {
     process.env.BRING_EMAIL = 'test@example.com';
     process.env.BRING_PASSWORD = 'password';
-
-    // Dynamically import to trigger script execution
-    await import('../src/index.js');
-
-    // Check if StdioServerTransport constructor was called (via the mock in helpers.ts)
-    // No direct way to check constructor call count of the class itself, but McpServer.connect uses its instance.
-    // We rely on the mockMcpServerInstance.connect to have been called with the instance from mockStdioServerTransportInstance.
-    expect(mockMcpServerInstance.connect).toHaveBeenCalledTimes(1);
-    expect(mockMcpServerInstance.connect).toHaveBeenCalledWith(mockStdioServerTransportInstance); // Ensure it's called with the correct transport instance
-    expect(mockConsoleError).toHaveBeenCalledWith('MCP server for Bring! API is running on STDIO');
-    expect(mockExit).not.toHaveBeenCalled();
-  });
-
-  it('should log an error and exit if BRING_EMAIL and its legacy alias are missing', async () => {
-    delete process.env.BRING_EMAIL;
-    delete process.env.MAIL;
-    process.env.BRING_PASSWORD = 'password';
-
-    await import('../src/index.js');
-
-    expect(mockConsoleError).toHaveBeenCalledWith(
-      expect.stringContaining('Missing BRING_EMAIL or BRING_PASSWORD environment variables'),
-    );
-    expect(mockExit).toHaveBeenCalledWith(1);
-    expect(mockMcpServerInstance.connect).not.toHaveBeenCalled();
-  });
-
-  it('should log an error and exit if BRING_PASSWORD and its legacy alias are missing', async () => {
-    process.env.BRING_EMAIL = 'test@example.com';
-    delete process.env.BRING_PASSWORD;
-    delete process.env.PW;
-
-    await import('../src/index.js');
-
-    expect(mockConsoleError).toHaveBeenCalledWith(
-      expect.stringContaining('Missing BRING_EMAIL or BRING_PASSWORD environment variables'),
-    );
-    expect(mockExit).toHaveBeenCalledWith(1);
-    expect(mockMcpServerInstance.connect).not.toHaveBeenCalled();
-  });
-
-  it('should log an error and exit if all supported credential environment variables are missing', async () => {
-    delete process.env.BRING_EMAIL;
-    delete process.env.BRING_PASSWORD;
     delete process.env.MAIL;
     delete process.env.PW;
+    const { main } = await import('../src/index.js');
 
-    await import('../src/index.js');
+    main();
 
-    expect(mockConsoleError).toHaveBeenCalledWith(
-      expect.stringContaining('Missing BRING_EMAIL or BRING_PASSWORD environment variables'),
-    );
-    expect(mockExit).toHaveBeenCalledWith(1);
-    expect(mockMcpServerInstance.connect).not.toHaveBeenCalled();
+    expect(mockServeStdio).toHaveBeenCalledWith(expect.any(Function), {
+      legacy: 'serve',
+      onerror: expect.any(Function),
+    });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/^MCP server for Bring! API v.+ is running/));
   });
 
-  // Test the catch block of main
-  it('should log fatal error and exit if server.connect throws', async () => {
-    process.env.BRING_EMAIL = 'test@example.com';
-    process.env.BRING_PASSWORD = 'password';
-
-    const connectError = new Error('Connection failed');
-    mockMcpServerInstance.connect.mockRejectedValueOnce(connectError);
-
-    await import('../src/index.js');
-
-    expect(mockMcpServerInstance.connect).toHaveBeenCalledTimes(1);
-    expect(mockConsoleError).toHaveBeenCalledWith('Fatal error starting MCP server:', connectError);
-    expect(mockExit).toHaveBeenCalledWith(1);
-  });
-
-  it('should support MAIL and PW as deprecated aliases', async () => {
+  it('logs the credential deprecation warning during startup', async () => {
     delete process.env.BRING_EMAIL;
     delete process.env.BRING_PASSWORD;
     process.env.MAIL = 'legacy@example.com';
     process.env.PW = 'legacy-password';
+    const { main } = await import('../src/index.js');
 
-    await import('../src/index.js');
+    main();
 
-    expect(mockMcpServerInstance.connect).toHaveBeenCalledTimes(1);
-    expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Deprecation warning'));
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Deprecation warning'));
   });
 
-  const expectedToolNames = [
-    'loadLists',
-    'getItems',
-    'getItemsDetails',
-    'saveItem',
-    'saveItemBatch',
-    'removeItem',
-    'moveToRecentList',
-    'saveItemImage',
-    'removeItemImage',
-    'getAllUsersFromList',
-    'getUserSettings',
-    'loadTranslations',
-    'loadCatalog',
-    'getPendingInvitations',
-    'deleteMultipleItemsFromList',
-    'getDefaultList',
-  ];
+  it('registers exactly 16 fully described tools', async () => {
+    await loadServer();
 
-  it('should register all expected tools on McpServer', async () => {
-    process.env.BRING_EMAIL = 'test@example.com';
-    process.env.BRING_PASSWORD = 'password';
-
-    await import('../src/index.js');
-
+    expect(mockMcpServerConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'bring-mcp',
+        title: 'Bring! Shopping Lists',
+        version: 'test-version',
+        websiteUrl: expect.stringContaining('github.com'),
+      }),
+      expect.objectContaining({ instructions: expect.stringContaining('getDefaultList') }),
+    );
     expect(mockMcpServerInstance.registerTool).toHaveBeenCalledTimes(expectedToolNames.length);
+    expect([...mockTools.keys()]).toEqual(expectedToolNames);
 
-    for (const toolName of expectedToolNames) {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        toolName,
+    for (const tool of mockTools.values()) {
+      expect(tool.title).not.toBe('');
+      expect(tool.description).not.toBe('');
+      expect(tool.inputSchema).toEqual(expect.objectContaining({ '~standard': expect.any(Object) }));
+      expect(tool.outputSchema).toEqual(expect.objectContaining({ '~standard': expect.any(Object) }));
+      expect(tool.annotations).toEqual(
         expect.objectContaining({
-          description: expect.any(String),
-          inputSchema: expect.any(Object),
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({
-            readOnlyHint: expect.any(Boolean),
-            destructiveHint: expect.any(Boolean),
-            idempotentHint: expect.any(Boolean),
-            openWorldHint: true,
-          }),
+          readOnlyHint: expect.any(Boolean),
+          destructiveHint: expect.any(Boolean),
+          idempotentHint: expect.any(Boolean),
+          openWorldHint: true,
         }),
-        expect.any(Function),
       );
     }
   });

--- a/tests/items.spec.ts
+++ b/tests/items.spec.ts
@@ -1,476 +1,156 @@
 import {
+  getTool,
+  loadServer,
+  mockDeleteMultipleItemsFromList,
   mockGetItems,
   mockGetItemsDetails,
+  mockMoveToRecentList,
+  mockRemoveItem,
   mockSaveItem,
   mockSaveItemBatch,
-  mockRemoveItem,
-  mockMoveToRecentList,
-  mockMcpServerInstance,
   mockTools,
-  loadServer,
-  getTool,
-  mockDeleteMultipleItemsFromList,
-} from './helpers'; // Import from helpers
+} from './helpers';
 
-let consoleErrorSpy: jest.SpyInstance;
+describe('item tools', () => {
+  let consoleErrorSpy: jest.SpyInstance;
 
-describe('MCP Bring! Server - Item Tools', () => {
   beforeEach(async () => {
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     jest.clearAllMocks();
     mockTools.clear();
     await loadServer();
   });
 
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
-  });
+  afterEach(() => consoleErrorSpy.mockRestore());
 
-  describe('bring.getItems tool', () => {
-    it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'getItems',
-        expect.objectContaining({
-          description: 'Get all items from a specific shopping list.',
-          inputSchema: expect.objectContaining({ listUuid: expect.anything() }),
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
-        }),
-        expect.any(Function),
-      );
-      const tool = getTool('getItems');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe('Get all items from a specific shopping list.');
-      expect(tool?.schema).toMatchObject({ listUuid: {} });
-    });
-
-    it('should call BringClient.getItems with listUuid and return items', async () => {
-      const fakeListUuid = 'test-list-uuid';
-      const fakeItemsInput = [{ id: 'item1', name: 'Milk', specification: '1L' }];
-      // This is what mockGetItems (from BringClient) should now resolve to
-      const fakeItemsExpectedByTool = fakeItemsInput.map((item) => ({ ...item, itemId: item.name }));
-
-      mockGetItems.mockResolvedValue(fakeItemsExpectedByTool);
-
-      const getItemsTool = getTool('getItems');
-      if (!getItemsTool) throw new Error('Tool getItems not found');
-      const result = await getItemsTool.callback({ listUuid: fakeListUuid });
-
-      expect(mockGetItems).toHaveBeenCalledWith(fakeListUuid);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: JSON.stringify(fakeItemsExpectedByTool, null, 2) }],
-        structuredContent: { result: fakeItemsExpectedByTool },
+  it('registers read and mutation tools with complete metadata', () => {
+    for (const name of ['getItems', 'getItemsDetails']) {
+      expect(getTool(name)).toMatchObject({
+        title: expect.any(String),
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
       });
-    });
+    }
 
-    it('should include itemId in purchase and recently items', async () => {
-      const fakeListUuid = 'test-list-uuid';
-      // This now represents the data *after* BringClient.getItems has processed it
-      const mockTransformedApiResponse = {
-        uuid: fakeListUuid,
-        status: 'SHARED',
-        purchase: [
-          { name: 'Milk', specification: '1L', itemId: 'Milk' },
-          { name: 'Eggs', specification: '12 pack', itemId: 'Eggs' },
-        ],
-        recently: [{ name: 'Bread', specification: 'Whole grain', itemId: 'Bread' }],
-      };
-      // mockGetItems (representing the mocked BringClient.getItems) should resolve
-      // with this transformed data.
-      mockGetItems.mockResolvedValue(mockTransformedApiResponse);
-
-      const tool = getTool('getItems');
-      if (!tool) throw new Error('Tool getItems not found');
-      const result = await tool.callback({ listUuid: fakeListUuid });
-
-      expect(mockGetItems).toHaveBeenCalledWith(fakeListUuid);
-      const parsedResult = JSON.parse((result.content[0] as { text: string }).text);
-
-      interface TestItem {
-        name: string;
-        specification: string;
-        itemId?: string;
-      }
-
-      // Check purchase items
-      expect(parsedResult.purchase).toBeInstanceOf(Array);
-      parsedResult.purchase.forEach((item: TestItem) => {
-        expect(item.itemId).toBe(item.name);
-        expect(item.name).not.toBeUndefined(); // ensure name is there for comparison
+    for (const name of ['saveItem', 'saveItemBatch', 'removeItem', 'moveToRecentList', 'deleteMultipleItemsFromList']) {
+      expect(getTool(name)).toMatchObject({
+        title: expect.any(String),
+        annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
       });
+      expect(getTool(name)?.inputSchema).toEqual(expect.objectContaining({ '~standard': expect.any(Object) }));
+      expect(getTool(name)?.outputSchema).toEqual(expect.objectContaining({ '~standard': expect.any(Object) }));
+    }
 
-      // Check recently items
-      expect(parsedResult.recently).toBeInstanceOf(Array);
-      parsedResult.recently.forEach((item: TestItem) => {
-        expect(item.itemId).toBe(item.name);
-        expect(item.name).not.toBeUndefined(); // ensure name is there for comparison
-      });
-    });
-
-    it('should return an error message on failed getItems', async () => {
-      const fakeListUuid = 'test-list-uuid';
-      const errorMessage = 'List not found';
-      mockGetItems.mockRejectedValue(new Error(errorMessage));
-
-      const getItemsTool = getTool('getItems');
-      if (!getItemsTool) throw new Error('Tool getItems not found');
-      const result = await getItemsTool.callback({ listUuid: fakeListUuid });
-
-      expect(mockGetItems).toHaveBeenCalledWith(fakeListUuid);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to get items: ${errorMessage}` }],
-        isError: true,
-      });
+    expect(getTool('saveItem')?.schema).toEqual({
+      listUuid: expect.anything(),
+      itemName: expect.anything(),
+      specification: expect.anything(),
     });
   });
 
-  describe('bring.getItemsDetails tool', () => {
-    it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'getItemsDetails',
-        expect.objectContaining({
-          description: 'Get details for items in a list. (Take listUuid)',
-          inputSchema: expect.objectContaining({ listUuid: expect.anything() }),
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
-        }),
-        expect.any(Function),
-      );
-      const tool = getTool('getItemsDetails');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe('Get details for items in a list. (Take listUuid)');
-      expect(tool?.schema).toMatchObject({ listUuid: {} }); // Schema has only listUuid
+  it('returns list items as natural structured content', async () => {
+    const items = {
+      uuid: 'list-1',
+      status: 'SHARED',
+      purchase: [{ name: 'Milk', specification: '1 L', itemId: 'Milk' }],
+      recently: [{ name: 'Bread', specification: '', itemId: 'Bread' }],
+    };
+    mockGetItems.mockResolvedValue(items);
+
+    const result = await getTool('getItems')!.callback({ listUuid: 'list-1' });
+
+    expect(mockGetItems).toHaveBeenCalledWith('list-1');
+    expect(result.structuredContent).toEqual(items);
+    expect(result.content[0]?.text).toBe(JSON.stringify(items, null, 2));
+  });
+
+  it('returns item details as a root array for MCP 2026 projection', async () => {
+    const details = [
+      {
+        uuid: 'detail-1',
+        itemId: 'Milk',
+        listUuid: 'list-1',
+        userIconItemId: '',
+        userSectionId: '',
+        assignedTo: '',
+        imageUrl: '',
+      },
+    ];
+    mockGetItemsDetails.mockResolvedValue(details);
+
+    const result = await getTool('getItemsDetails')!.callback({ listUuid: 'list-1' });
+
+    expect(mockGetItemsDetails).toHaveBeenCalledWith('list-1');
+    expect(result.structuredContent).toEqual(details);
+  });
+
+  it('normalizes a successful saveItem mutation', async () => {
+    mockSaveItem.mockResolvedValue('');
+
+    const result = await getTool('saveItem')!.callback({
+      listUuid: 'list-1',
+      itemName: 'Milk',
+      specification: '2 L',
     });
 
-    it('should call BringClient.getItemsDetails and return item details on success', async () => {
-      const fakeListUuid = 'list-123';
-      // itemId is not used by the tool's current implementation in src/index.ts
-      const fakeItemDetails = { id: 'item-abc', name: 'Detailed Milk', specification: 'Organic' };
-      mockGetItemsDetails.mockResolvedValue(fakeItemDetails);
-
-      const tool = getTool('getItemsDetails');
-      if (!tool) throw new Error('Tool getItemsDetails not found');
-      const result = await tool.callback({ listUuid: fakeListUuid }); // Corrected: only pass listUuid
-
-      expect(mockGetItemsDetails).toHaveBeenCalledWith(fakeListUuid); // Corrected: only expect listUuid
-      expect(result).toEqual({
-        content: [{ type: 'text', text: JSON.stringify(fakeItemDetails, null, 2) }],
-        structuredContent: { result: fakeItemDetails },
-      });
-    });
-
-    it('should return an error message on failed getItemsDetails', async () => {
-      const fakeListUuid = 'list-123';
-      // itemId is not used by the tool's current implementation in src/index.ts
-      const errorMessage = 'Item details not found';
-      mockGetItemsDetails.mockRejectedValue(new Error(errorMessage));
-      const tool = getTool('getItemsDetails');
-      if (!tool) throw new Error('Tool getItemsDetails not found');
-      const result = await tool.callback({ listUuid: fakeListUuid }); // Corrected: only pass listUuid
-      expect(mockGetItemsDetails).toHaveBeenCalledWith(fakeListUuid); // Corrected: only expect listUuid
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to get item details: ${errorMessage}` }],
-        isError: true,
-      });
+    expect(mockSaveItem).toHaveBeenCalledWith('list-1', 'Milk', '2 L');
+    expect(result.structuredContent).toEqual({
+      success: true,
+      listUuid: 'list-1',
+      itemName: 'Milk',
+      specification: '2 L',
     });
   });
 
-  describe('bring.saveItem tool', () => {
-    it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'saveItem',
-        expect.objectContaining({
-          description:
-            'Save an item to a shopping list. Use the "specification" parameter to add details like quantity or type (e.g., itemName: "Milk", specification: "2 liters").',
-          inputSchema: expect.objectContaining({
-            listUuid: expect.anything(),
-            itemName: expect.anything(),
-            specification: expect.anything(),
-          }),
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
-        }),
-        expect.any(Function),
-      );
-      const tool = getTool('saveItem');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe(
-        'Save an item to a shopping list. Use the "specification" parameter to add details like quantity or type (e.g., itemName: "Milk", specification: "2 liters").',
-      );
-      expect(tool?.schema).toMatchObject({ listUuid: {}, itemName: {}, specification: {} });
+  it('normalizes successful batch mutations', async () => {
+    const items = [{ itemName: 'Eggs', specification: '12' }, { itemName: 'Apples' }];
+    mockSaveItemBatch.mockResolvedValue(['', '']);
+    mockDeleteMultipleItemsFromList.mockResolvedValue(['', '']);
+
+    const saveResult = await getTool('saveItemBatch')!.callback({ listUuid: 'list-1', items });
+    const deleteResult = await getTool('deleteMultipleItemsFromList')!.callback({
+      listUuid: 'list-1',
+      itemNames: ['Eggs', 'Apples'],
     });
 
-    it('should call BringClient.saveItem and return success message on success (with spec)', async () => {
-      const fakeListUuid = 'list-123';
-      const fakeItemName = 'Eggs';
-      const fakeItemSpec = '6 pack';
-      const savedItemConfirmation = { itemId: 'item-xyz', message: 'Item saved successfully' };
-      mockSaveItem.mockResolvedValue(savedItemConfirmation);
-      const tool = getTool('saveItem');
-      if (!tool) throw new Error('Tool saveItem not found');
-      const result = await tool.callback({
-        listUuid: fakeListUuid,
-        itemName: fakeItemName,
-        specification: fakeItemSpec,
-      });
-      // This is the critical check. If args.specification is not passed correctly from Zod, this will fail.
-      expect(mockSaveItem).toHaveBeenCalledWith(fakeListUuid, fakeItemName, fakeItemSpec);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Item saved: ${JSON.stringify(savedItemConfirmation)}` }],
-        structuredContent: { result: savedItemConfirmation },
-      });
+    expect(mockSaveItemBatch).toHaveBeenCalledWith('list-1', items);
+    expect(saveResult.structuredContent).toEqual({
+      success: true,
+      listUuid: 'list-1',
+      count: 2,
+      items: [
+        { itemName: 'Eggs', specification: '12' },
+        { itemName: 'Apples', specification: null },
+      ],
     });
-
-    it('should return an error message on failed saveItem', async () => {
-      const fakeListUuid = 'list-123';
-      const fakeItemName = 'Eggs';
-      const fakeItemSpec = '6 pack';
-      const errorMessage = 'Could not save item';
-      mockSaveItem.mockRejectedValue(new Error(errorMessage));
-      const tool = getTool('saveItem');
-      if (!tool) throw new Error('Tool saveItem not found');
-      const result = await tool.callback({
-        listUuid: fakeListUuid,
-        itemName: fakeItemName,
-        specification: fakeItemSpec,
-      });
-      expect(mockSaveItem).toHaveBeenCalledWith(fakeListUuid, fakeItemName, fakeItemSpec);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to save item: ${errorMessage}` }],
-        isError: true,
-      });
+    expect(mockDeleteMultipleItemsFromList).toHaveBeenCalledWith('list-1', ['Eggs', 'Apples']);
+    expect(deleteResult.structuredContent).toEqual({
+      success: true,
+      listUuid: 'list-1',
+      count: 2,
+      itemNames: ['Eggs', 'Apples'],
     });
   });
 
-  describe('bring.removeItem tool', () => {
-    it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'removeItem',
-        expect.objectContaining({
-          description: 'Remove an item from a specific shopping list.',
-          inputSchema: expect.objectContaining({ listUuid: expect.anything(), itemId: expect.anything() }),
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
-        }),
-        expect.any(Function),
-      );
-      const tool = getTool('removeItem');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe('Remove an item from a specific shopping list.'); // Corrected
-      expect(tool?.schema).toMatchObject({ listUuid: {}, itemId: {} });
-    });
+  it.each([
+    ['removeItem', mockRemoveItem],
+    ['moveToRecentList', mockMoveToRecentList],
+  ])('normalizes the %s mutation', async (toolName, apiMock) => {
+    apiMock.mockResolvedValue('');
 
-    it('should call BringClient.removeItem and return success message', async () => {
-      const fakeListUuid = 'list-123';
-      const fakeItemId = 'item-toremove';
-      const successResponse = { message: 'Item removed successfully' };
-      mockRemoveItem.mockResolvedValue(successResponse);
+    const result = await getTool(toolName)!.callback({ listUuid: 'list-1', itemId: 'Milk' });
 
-      const tool = getTool('removeItem');
-      if (!tool) throw new Error('Tool removeItem not found');
-      const result = await tool.callback({ listUuid: fakeListUuid, itemId: fakeItemId });
-
-      expect(mockRemoveItem).toHaveBeenCalledWith(fakeListUuid, fakeItemId);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: JSON.stringify(successResponse, null, 2) }],
-        structuredContent: { result: successResponse },
-      });
-    });
-
-    it('should return an error message on failed removeItem', async () => {
-      const fakeListUuid = 'list-123';
-      const fakeItemId = 'item-toremove';
-      const errorMessage = 'Could not remove item';
-      mockRemoveItem.mockRejectedValue(new Error(errorMessage));
-
-      const tool = getTool('removeItem');
-      if (!tool) throw new Error('Tool removeItem not found');
-      const result = await tool.callback({ listUuid: fakeListUuid, itemId: fakeItemId });
-
-      expect(mockRemoveItem).toHaveBeenCalledWith(fakeListUuid, fakeItemId);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to remove item: ${errorMessage}` }],
-        isError: true,
-      });
-    });
+    expect(apiMock).toHaveBeenCalledWith('list-1', 'Milk');
+    expect(result.structuredContent).toEqual({ success: true, listUuid: 'list-1', itemId: 'Milk' });
   });
 
-  describe('bring.moveToRecentList tool', () => {
-    it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'moveToRecentList',
-        expect.objectContaining({
-          description: 'Move an item from a shopping list to the recently used items list.',
-          inputSchema: expect.objectContaining({ listUuid: expect.anything(), itemId: expect.anything() }),
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
-        }),
-        expect.any(Function),
-      );
-      const tool = getTool('moveToRecentList');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe('Move an item from a shopping list to the recently used items list.'); // Corrected
-      expect(tool?.schema).toMatchObject({ listUuid: {}, itemId: {} });
-    });
+  it('marks API failures as MCP errors', async () => {
+    mockRemoveItem.mockRejectedValue(new Error('Mutation failed'));
 
-    it('should call BringClient.moveToRecentList and return success message', async () => {
-      const fakeListUuid = 'list-123';
-      const fakeItemId = 'item-tomove';
-      const successResponse = { message: 'Item moved successfully' };
-      mockMoveToRecentList.mockResolvedValue(successResponse);
+    const result = await getTool('removeItem')!.callback({ listUuid: 'list-1', itemId: 'Milk' });
 
-      const tool = getTool('moveToRecentList');
-      if (!tool) throw new Error('Tool moveToRecentList not found');
-      const result = await tool.callback({ listUuid: fakeListUuid, itemId: fakeItemId });
-
-      expect(mockMoveToRecentList).toHaveBeenCalledWith(fakeListUuid, fakeItemId);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: JSON.stringify(successResponse, null, 2) }],
-        structuredContent: { result: successResponse },
-      });
-    });
-
-    it('should return an error message on failed moveToRecentList', async () => {
-      const fakeListUuid = 'list-123';
-      const fakeItemId = 'item-tomove';
-      const errorMessage = 'Could not move item';
-      mockMoveToRecentList.mockRejectedValue(new Error(errorMessage));
-
-      const tool = getTool('moveToRecentList');
-      if (!tool) throw new Error('Tool moveToRecentList not found');
-      const result = await tool.callback({ listUuid: fakeListUuid, itemId: fakeItemId });
-
-      expect(mockMoveToRecentList).toHaveBeenCalledWith(fakeListUuid, fakeItemId);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to move item to recent list: ${errorMessage}` }],
-        isError: true,
-      });
-    });
-  });
-
-  describe('bring.saveItemBatch tool', () => {
-    it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'saveItemBatch',
-        expect.objectContaining({
-          description:
-            'Save multiple items to a shopping list. For each item, you can provide an "itemName" and an optional "specification" for details like quantity or type (input e.g., [{ "itemName": "Eggs", "specification": "dozen" },{ "itemName":"Apples", "specification": "10" }]).',
-          inputSchema: expect.objectContaining({ listUuid: expect.anything(), items: expect.anything() }),
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
-        }),
-        expect.any(Function),
-      );
-      const tool = getTool('saveItemBatch');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe(
-        'Save multiple items to a shopping list. For each item, you can provide an "itemName" and an optional "specification" for details like quantity or type (input e.g., [{ "itemName": "Eggs", "specification": "dozen" },{ "itemName":"Apples", "specification": "10" }]).',
-      );
-      // Check for listUuid and items properties in the schema
-      expect(tool?.schema).toMatchObject({ listUuid: {}, items: {} });
-    });
-
-    it('should call BringClient.saveItemBatch with correct arguments and return success message', async () => {
-      const fakeListUuid = 'list-batch-save';
-      const fakeItems = [
-        { itemName: 'Milk', specification: '1 liter' },
-        { itemName: 'Bread' }, // No specification
-      ];
-      const successResponse = [{ itemId: 'milk-123' }, { itemId: 'bread-456' }];
-      mockSaveItemBatch.mockResolvedValue(successResponse);
-
-      const tool = getTool('saveItemBatch');
-      if (!tool) throw new Error('Tool saveItemBatch not found');
-      const result = await tool.callback({ listUuid: fakeListUuid, items: fakeItems });
-
-      expect(mockSaveItemBatch).toHaveBeenCalledWith(fakeListUuid, fakeItems);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Batch items saved: ${JSON.stringify(successResponse)}` }],
-        structuredContent: { result: successResponse },
-      });
-    });
-
-    it('should return an error message on failed saveItemBatch', async () => {
-      const fakeListUuid = 'list-batch-save-fail';
-      const fakeItems = [{ itemName: 'Sugar' }];
-      const errorMessage = 'Batch save failed';
-      mockSaveItemBatch.mockRejectedValue(new Error(errorMessage));
-
-      const tool = getTool('saveItemBatch');
-      if (!tool) throw new Error('Tool saveItemBatch not found');
-      const result = await tool.callback({ listUuid: fakeListUuid, items: fakeItems });
-
-      expect(mockSaveItemBatch).toHaveBeenCalledWith(fakeListUuid, fakeItems);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to save batch items: ${errorMessage}` }],
-        isError: true,
-      });
-    });
-  });
-
-  describe('bring.deleteMultipleItemsFromList tool', () => {
-    const listUuid = 'test-list-uuid';
-    const itemNamesToDelete = ['ItemA', 'ItemB'];
-
-    it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'deleteMultipleItemsFromList',
-        expect.objectContaining({
-          description: 'Delete multiple items from a specific shopping list by their names.',
-          inputSchema: expect.objectContaining({ listUuid: expect.anything(), itemNames: expect.anything() }),
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: false, destructiveHint: true }),
-        }),
-        expect.any(Function),
-      );
-      const tool = getTool('deleteMultipleItemsFromList');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe('Delete multiple items from a specific shopping list by their names.');
-      expect(tool?.schema).toMatchObject({
-        listUuid: expect.anything(),
-        itemNames: expect.anything(),
-      });
-      const itemNamesSchema = (tool?.schema as { itemNames: { safeParse: (value: unknown) => { success: boolean } } })
-        .itemNames;
-      expect(itemNamesSchema.safeParse(['ItemA']).success).toBe(true);
-      expect(itemNamesSchema.safeParse([]).success).toBe(false);
-    });
-
-    it('should call BringClient.deleteMultipleItemsFromList and return success', async () => {
-      const mockSuccessResponse = { count: itemNamesToDelete.length, status: 'deleted' };
-      mockDeleteMultipleItemsFromList.mockResolvedValue(mockSuccessResponse);
-
-      const tool = getTool('deleteMultipleItemsFromList');
-      if (!tool) throw new Error('Tool deleteMultipleItemsFromList not found');
-
-      const result = await tool.callback({ listUuid, itemNames: itemNamesToDelete });
-
-      expect(mockDeleteMultipleItemsFromList).toHaveBeenCalledTimes(1);
-      expect(mockDeleteMultipleItemsFromList).toHaveBeenCalledWith(listUuid, itemNamesToDelete);
-
-      // Uses transformResult from itemTools.ts
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Multiple items deleted: ${JSON.stringify(mockSuccessResponse)}` }],
-        structuredContent: { result: mockSuccessResponse },
-      });
-    });
-
-    it('should return an error message if BringClient.deleteMultipleItemsFromList fails', async () => {
-      const errorMessage = 'Failed to delete from client';
-      mockDeleteMultipleItemsFromList.mockRejectedValueOnce(new Error(errorMessage));
-
-      const tool = getTool('deleteMultipleItemsFromList');
-      if (!tool) throw new Error('Tool deleteMultipleItemsFromList not found');
-
-      const result = await tool.callback({ listUuid, itemNames: itemNamesToDelete });
-
-      expect(mockDeleteMultipleItemsFromList).toHaveBeenCalledTimes(1);
-      expect(mockDeleteMultipleItemsFromList).toHaveBeenCalledWith(listUuid, itemNamesToDelete);
-
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to delete multiple items: ${errorMessage}` }],
-        isError: true,
-      });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Failed to remove item: Mutation failed' }],
+      isError: true,
     });
   });
 });

--- a/tests/lists.spec.ts
+++ b/tests/lists.spec.ts
@@ -1,75 +1,58 @@
-import {
-  mockLoadLists, // Specific mock for this tool
-  mockMcpServerInstance,
-  mockTools,
-  loadServer,
-  getTool,
-} from './helpers';
+import { getTool, loadServer, mockLoadLists, mockTools } from './helpers';
 
-let consoleErrorSpy: jest.SpyInstance;
+describe('loadLists tool', () => {
+  let consoleErrorSpy: jest.SpyInstance;
 
-describe('MCP Bring! Server - List Tools', () => {
   beforeEach(async () => {
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     jest.clearAllMocks();
     mockTools.clear();
     await loadServer();
   });
 
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
+  afterEach(() => consoleErrorSpy.mockRestore());
+
+  it('registers a read-only tool with complete input and output schemas', () => {
+    const tool = getTool('loadLists');
+
+    expect(tool).toMatchObject({
+      title: 'Load Shopping Lists',
+      description: 'Load all shopping lists from Bring!',
+      schema: {},
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    });
+    expect(tool?.outputSchema).toEqual(expect.objectContaining({ '~standard': expect.any(Object) }));
   });
 
-  describe('bring.loadLists tool', () => {
-    it('should be registered with correct name, description, and schema', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'loadLists',
-        expect.objectContaining({
-          description: 'Load all shopping lists from Bring!',
-          inputSchema: {},
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
-        }),
-        expect.any(Function), // Callback
-      );
-      const tool = getTool('loadLists');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe('Load all shopping lists from Bring!');
-      expect(tool?.schema).toEqual({});
-      expect(tool?.annotations).toMatchObject({ readOnlyHint: true, destructiveHint: false });
+  it('returns the API response as structured content', async () => {
+    const lists = {
+      lists: [
+        { listUuid: '11111111-1111-4111-8111-111111111111', name: 'Groceries', theme: 'ch.publisheria.bring.theme.1' },
+      ],
+    };
+    mockLoadLists.mockResolvedValue(lists);
+
+    const result = await getTool('loadLists')!.callback({});
+
+    expect(mockLoadLists).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      content: [{ type: 'text', text: JSON.stringify(lists, null, 2) }],
+      structuredContent: lists,
     });
+  });
 
-    it('should call BringClient.loadLists and return lists on success', async () => {
-      const fakeLists = [
-        { listUuid: 'uuid1', name: 'Groceries' },
-        { listUuid: 'uuid2', name: 'Work' },
-      ];
-      mockLoadLists.mockResolvedValue(fakeLists);
+  it('marks API and response-validation failures as MCP errors', async () => {
+    mockLoadLists.mockRejectedValueOnce(new Error('Network error'));
+    const apiFailure = await getTool('loadLists')!.callback({});
 
-      const tool = getTool('loadLists');
-      if (!tool) throw new Error('Tool loadLists not found');
-      const result = await tool.callback({});
+    mockLoadLists.mockResolvedValueOnce({ unexpected: true });
+    const schemaFailure = await getTool('loadLists')!.callback({});
 
-      expect(mockLoadLists).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: JSON.stringify(fakeLists, null, 2) }],
-        structuredContent: { result: fakeLists },
-      });
+    expect(apiFailure).toEqual({
+      content: [{ type: 'text', text: 'Failed to load lists: Network error' }],
+      isError: true,
     });
-
-    it('should return an error message on failed loadLists', async () => {
-      const errorMessage = 'Network error';
-      mockLoadLists.mockRejectedValue(new Error(errorMessage));
-
-      const tool = getTool('loadLists');
-      if (!tool) throw new Error('Tool loadLists not found');
-      const result = await tool.callback({});
-
-      expect(mockLoadLists).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to load lists: ${errorMessage}` }],
-        isError: true,
-      });
-    });
+    expect(schemaFailure.isError).toBe(true);
+    expect(schemaFailure.content[0]?.text).toContain('Failed to load lists');
   });
 });

--- a/tests/protocol.spec.ts
+++ b/tests/protocol.spec.ts
@@ -1,0 +1,150 @@
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport } from '@modelcontextprotocol/server';
+import { serveStdio, type StdioServerHandle } from '@modelcontextprotocol/server/stdio';
+import type { BringService } from '../src/bringClient.js';
+import { createBringServer } from '../src/server.js';
+
+const listUuid = '11111111-1111-4111-8111-111111111111';
+
+function createFakeBringService(): BringService {
+  return {
+    loadLists: jest.fn().mockResolvedValue({
+      lists: [{ listUuid, name: 'Groceries', theme: 'ch.publisheria.bring.theme.1' }],
+    }),
+    getItems: jest.fn().mockResolvedValue({
+      uuid: listUuid,
+      status: 'SHARED',
+      purchase: [{ name: 'Milk', specification: '1 L', itemId: 'Milk' }],
+      recently: [],
+    }),
+    getItemsDetails: jest.fn().mockResolvedValue([
+      {
+        uuid: 'detail-1',
+        itemId: 'Milk',
+        listUuid,
+        userIconItemId: '',
+        userSectionId: '',
+        assignedTo: '',
+        imageUrl: '',
+      },
+    ]),
+    saveItem: jest.fn().mockResolvedValue(''),
+    saveItemBatch: jest.fn().mockResolvedValue([]),
+    removeItem: jest.fn().mockResolvedValue(''),
+    moveToRecentList: jest.fn().mockResolvedValue(''),
+    saveItemImage: jest.fn().mockResolvedValue({ imageUrl: 'https://example.test/item.jpg' }),
+    removeItemImage: jest.fn().mockResolvedValue(''),
+    getAllUsersFromList: jest.fn().mockResolvedValue({ users: [] }),
+    getUserSettings: jest.fn().mockResolvedValue({
+      userSettings: [{ key: 'defaultListUUID', value: listUuid }],
+      userlistsettings: [],
+    }),
+    loadTranslations: jest.fn().mockResolvedValue({ Milk: 'Milk' }),
+    loadCatalog: jest.fn().mockResolvedValue({
+      language: 'en-US',
+      catalog: { sections: [] },
+    }),
+    getPendingInvitations: jest.fn().mockResolvedValue({ invitations: [] }),
+    deleteMultipleItemsFromList: jest.fn().mockResolvedValue([]),
+  } as BringService;
+}
+
+async function connectClient(mode: 'legacy' | 'modern', service = createFakeBringService()) {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const serverHandle: StdioServerHandle = serveStdio(() => createBringServer(service, '2.0.0-test'), {
+    legacy: 'serve',
+    transport: serverTransport,
+  });
+  const client = new Client(
+    { name: `bring-mcp-${mode}-test`, version: '1.0.0' },
+    mode === 'modern'
+      ? {
+          versionNegotiation: { mode: { pin: '2026-07-28' } },
+        }
+      : undefined,
+  );
+  await client.connect(clientTransport);
+  return { client, serverHandle };
+}
+
+async function closeConnection(client: Client, serverHandle: StdioServerHandle): Promise<void> {
+  await client.close();
+  await serverHandle.close();
+}
+
+describe.each(['legacy', 'modern'] as const)('%s MCP protocol', (mode) => {
+  it('negotiates, discovers all tools, and calls an object-output tool', async () => {
+    const { client, serverHandle } = await connectClient(mode);
+    try {
+      const tools = await client.listTools();
+      const result = await client.callTool({ name: 'loadLists', arguments: {} });
+
+      expect(client.getServerVersion()).toMatchObject({
+        name: 'bring-mcp',
+        title: 'Bring! Shopping Lists',
+        version: '2.0.0-test',
+      });
+      expect(client.getInstructions()).toContain('getDefaultList');
+      expect(tools.tools).toHaveLength(16);
+      expect(tools.tools.every((tool) => tool.title && tool.inputSchema && tool.outputSchema)).toBe(true);
+      expect(result.isError).not.toBe(true);
+      expect(result.structuredContent).toEqual({
+        lists: [{ listUuid, name: 'Groceries', theme: 'ch.publisheria.bring.theme.1' }],
+      });
+    } finally {
+      await closeConnection(client, serverHandle);
+    }
+  });
+
+  it('projects root-array output according to the negotiated protocol era', async () => {
+    const { client, serverHandle } = await connectClient(mode);
+    try {
+      const tools = await client.listTools();
+      const detailsTool = tools.tools.find((tool) => tool.name === 'getItemsDetails');
+      const result = await client.callTool({ name: 'getItemsDetails', arguments: { listUuid } });
+      const expectedDetails = [
+        {
+          uuid: 'detail-1',
+          itemId: 'Milk',
+          listUuid,
+          userIconItemId: '',
+          userSectionId: '',
+          assignedTo: '',
+          imageUrl: '',
+        },
+      ];
+
+      const expectedProtocolVersion = mode === 'modern' ? '2026-07-28' : '2025-11-25';
+      const outputSchemas = {
+        modern: { type: 'array' },
+        legacy: {
+          type: 'object',
+          properties: { result: expect.objectContaining({ type: 'array' }) },
+        },
+      };
+      const expectedStructuredContent = mode === 'modern' ? expectedDetails : { result: expectedDetails };
+
+      expect(client.getNegotiatedProtocolVersion()).toBe(expectedProtocolVersion);
+      expect(detailsTool?.outputSchema).toMatchObject(outputSchemas[mode]);
+      expect(result.structuredContent).toEqual(expectedStructuredContent);
+    } finally {
+      await closeConnection(client, serverHandle);
+    }
+  });
+
+  it('preserves tool failures as isError results over the wire', async () => {
+    const service = createFakeBringService();
+    jest.mocked(service.getItems).mockRejectedValue(new Error('Bring API unavailable'));
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { client, serverHandle } = await connectClient(mode, service);
+    try {
+      const result = await client.callTool({ name: 'getItems', arguments: { listUuid } });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContainEqual({ type: 'text', text: 'Failed to get items: Bring API unavailable' });
+    } finally {
+      consoleErrorSpy.mockRestore();
+      await closeConnection(client, serverHandle);
+    }
+  });
+});

--- a/tests/users.spec.ts
+++ b/tests/users.spec.ts
@@ -1,337 +1,136 @@
 import {
-  mockGetAllUsersFromList,
-  mockGetUserSettings,
-  mockGetPendingInvitations,
-  mockLoadLists,
-  mockMcpServerInstance,
-  mockTools,
-  loadServer,
   getTool,
+  loadServer,
+  mockGetAllUsersFromList,
+  mockGetPendingInvitations,
+  mockGetUserSettings,
+  mockLoadLists,
+  mockTools,
 } from './helpers';
 
-let consoleErrorSpy: jest.SpyInstance;
+describe('user tools', () => {
+  let consoleErrorSpy: jest.SpyInstance;
 
-// Placeholder for user tests
-describe('User Tests', () => {
-  it('should have a placeholder test', () => {
-    expect(true).toBe(true);
-  });
-});
-
-describe('MCP Bring! Server - User Tools', () => {
   beforeEach(async () => {
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     jest.clearAllMocks();
     mockTools.clear();
     await loadServer();
   });
 
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
+  afterEach(() => consoleErrorSpy.mockRestore());
+
+  it('registers complete schemas and read-only annotations', () => {
+    for (const name of ['getAllUsersFromList', 'getUserSettings', 'getPendingInvitations', 'getDefaultList']) {
+      const tool = getTool(name);
+      expect(tool?.title).not.toBe('');
+      expect(tool?.inputSchema).toEqual(expect.objectContaining({ '~standard': expect.any(Object) }));
+      expect(tool?.outputSchema).toEqual(expect.objectContaining({ '~standard': expect.any(Object) }));
+      expect(tool?.annotations).toMatchObject({ readOnlyHint: true, destructiveHint: false, idempotentHint: true });
+    }
+    expect(getTool('getAllUsersFromList')?.schema).toEqual({ listUuid: expect.anything() });
+    expect(getTool('getUserSettings')?.schema).toEqual({});
   });
 
-  // Test for getAllUsersFromList
-  describe('bring.getAllUsersFromList tool', () => {
-    const toolSchema = { listUuid: expect.any(Object) }; // Zod string
-
-    it('should be registered correctly', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'getAllUsersFromList',
-        expect.objectContaining({
-          description: 'Get all users associated with a specific shopping list.',
-          inputSchema: toolSchema,
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
-        }),
-        expect.any(Function),
-      );
-      const tool = getTool('getAllUsersFromList');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe('Get all users associated with a specific shopping list.');
-      expect(tool?.schema).toMatchObject({ listUuid: {} });
-    });
-
-    it('should return users on success', async () => {
-      const fakeListUuid = 'list-users';
-      const fakeUsers = [
-        { id: 'user1', name: 'Alice' },
-        { id: 'user2', name: 'Bob' },
-      ];
-      mockGetAllUsersFromList.mockResolvedValue(fakeUsers);
-      const tool = getTool('getAllUsersFromList');
-      if (!tool) throw new Error('Tool getAllUsersFromList not found');
-      const result = await tool.callback({ listUuid: fakeListUuid });
-      expect(mockGetAllUsersFromList).toHaveBeenCalledWith(fakeListUuid);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: JSON.stringify(fakeUsers, null, 2) }],
-        structuredContent: { result: fakeUsers },
-      });
-    });
-
-    it('should return error on failure', async () => {
-      const fakeListUuid = 'list-users-fail';
-      const error = new Error('Failed to get users');
-      mockGetAllUsersFromList.mockRejectedValue(error);
-      const tool = getTool('getAllUsersFromList');
-      if (!tool) throw new Error('Tool getAllUsersFromList not found');
-      const result = await tool.callback({ listUuid: fakeListUuid });
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to get all users from list: ${error.message}` }],
-        isError: true,
-      });
-    });
-  });
-
-  // Test for getUserSettings
-  describe('bring.getUserSettings tool', () => {
-    it('should be registered correctly', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'getUserSettings',
-        expect.objectContaining({
-          description: 'Get the settings for the current authenticated user.',
-          inputSchema: {},
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
-        }),
-        expect.any(Function),
-      );
-      const tool = getTool('getUserSettings');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe('Get the settings for the current authenticated user.');
-      expect(tool?.schema).toEqual({});
-    });
-
-    it('should return settings on success', async () => {
-      const fakeSettings = { theme: 'dark', notifications: true };
-      mockGetUserSettings.mockResolvedValue(fakeSettings);
-      const tool = getTool('getUserSettings');
-      if (!tool) throw new Error('Tool getUserSettings not found');
-      const result = await tool.callback({});
-      expect(mockGetUserSettings).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: JSON.stringify(fakeSettings, null, 2) }],
-        structuredContent: { result: fakeSettings },
-      });
-    });
-
-    it('should return error on failure', async () => {
-      const error = new Error('Failed to get settings');
-      mockGetUserSettings.mockRejectedValue(error);
-      const tool = getTool('getUserSettings');
-      if (!tool) throw new Error('Tool getUserSettings not found');
-      const result = await tool.callback({});
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to get user settings: ${error.message}` }],
-        isError: true,
-      });
-    });
-  });
-
-  // Test for getPendingInvitations
-  describe('bring.getPendingInvitations tool', () => {
-    it('should be registered correctly', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'getPendingInvitations',
-        expect.objectContaining({
-          description: 'Get any pending invitations for the authenticated user to join shopping lists.',
-          inputSchema: {},
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
-        }),
-        expect.any(Function),
-      );
-      const tool = getTool('getPendingInvitations');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe('Get any pending invitations for the authenticated user to join shopping lists.');
-      expect(tool?.schema).toEqual({});
-    });
-
-    it('should return invitations on success', async () => {
-      const fakeInvitations = [{ listId: 'list-invite', fromUser: 'UserA' }];
-      mockGetPendingInvitations.mockResolvedValue(fakeInvitations);
-      const tool = getTool('getPendingInvitations');
-      if (!tool) throw new Error('Tool getPendingInvitations not found');
-      const result = await tool.callback({});
-      expect(mockGetPendingInvitations).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: JSON.stringify(fakeInvitations, null, 2) }],
-        structuredContent: { result: fakeInvitations },
-      });
-    });
-
-    it('should return error on failure', async () => {
-      const error = new Error('Failed to get invitations');
-      mockGetPendingInvitations.mockRejectedValue(error);
-      const tool = getTool('getPendingInvitations');
-      if (!tool) throw new Error('Tool getPendingInvitations not found');
-      const result = await tool.callback({});
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to get pending invitations: ${error.message}` }],
-        isError: true,
-      });
-    });
-  });
-
-  // Test for getDefaultList
-  describe('bring.getDefaultList tool', () => {
-    it('should be registered correctly', () => {
-      expect(mockMcpServerInstance.registerTool).toHaveBeenCalledWith(
-        'getDefaultList',
-        expect.objectContaining({
-          description:
-            'Get the UUID of the default shopping list for the authenticated user. Use this if the user does not ask for a special list.',
-          inputSchema: {},
-          outputSchema: expect.objectContaining({ result: expect.anything() }),
-          annotations: expect.objectContaining({ readOnlyHint: true, destructiveHint: false }),
-        }),
-        expect.any(Function),
-      );
-      const tool = getTool('getDefaultList');
-      expect(tool).toBeDefined();
-      expect(tool?.description).toBe(
-        'Get the UUID of the default shopping list for the authenticated user. Use this if the user does not ask for a special list.',
-      );
-      expect(tool?.schema).toEqual({});
-    });
-
-    it('should return default list UUID on success', async () => {
-      const fakeSettings = {
-        usersettings: [
-          { key: 'someOtherSetting', value: 'someValue' },
-          { key: 'defaultListUUID', value: 'default-list-uuid-123' },
-          { key: 'anotherSetting', value: 'anotherValue' },
-        ],
-      };
-      // We mock getUserSettings because getDefaultList calls it internally
-      mockGetUserSettings.mockResolvedValue(fakeSettings);
-      const tool = getTool('getDefaultList');
-      if (!tool) throw new Error('Tool getDefaultList not found');
-
-      const result = await tool.callback({});
-      expect(mockGetUserSettings).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: 'default-list-uuid-123' }],
-        structuredContent: { result: 'default-list-uuid-123' },
-      });
-    });
-
-    it('should return error if defaultListUUID is not found in settings', async () => {
-      const fakeSettingsWithoutUuid = {
-        usersettings: [
-          { key: 'someOtherSetting', value: 'someValue' },
-          { key: 'anotherSetting', value: 'anotherValue' },
-        ],
-      };
-      mockGetUserSettings.mockResolvedValue(fakeSettingsWithoutUuid);
-      mockLoadLists.mockResolvedValue({ lists: [] });
-      const tool = getTool('getDefaultList');
-      if (!tool) throw new Error('Tool getDefaultList not found');
-
-      const result = await tool.callback({});
-      expect(mockGetUserSettings).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({
-        content: [
-          {
-            type: 'text',
-            text: 'No default list is configured. Set one in the Bring app, or call loadLists to choose.',
-          },
-        ],
-        structuredContent: {
-          result: 'No default list is configured. Set one in the Bring app, or call loadLists to choose.',
+  it('returns users and invitations in their documented response objects', async () => {
+    const users = {
+      users: [
+        {
+          publicUuid: 'user-1',
+          name: 'Alice',
+          email: 'alice@example.test',
+          photoPath: '',
+          pushEnabled: true,
+          plusTryOut: false,
+          country: 'DE',
+          language: 'de-DE',
         },
-      });
-    });
+      ],
+    };
+    const invitations = { invitations: [{ listUuid: 'list-1' }] };
+    mockGetAllUsersFromList.mockResolvedValue(users);
+    mockGetPendingInvitations.mockResolvedValue(invitations);
 
-    it('should return error if getUserSettings fails', async () => {
-      const error = new Error('Failed to get user settings from API');
-      mockGetUserSettings.mockRejectedValue(error);
-      const tool = getTool('getDefaultList');
-      if (!tool) throw new Error('Tool getDefaultList not found');
+    const usersResult = await getTool('getAllUsersFromList')!.callback({ listUuid: 'list-1' });
+    const invitationResult = await getTool('getPendingInvitations')!.callback({});
 
-      const result = await tool.callback({});
-      expect(mockGetUserSettings).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: `Failed to get default list UUID: ${error.message}` }],
-        isError: true,
-      });
-    });
+    expect(mockGetAllUsersFromList).toHaveBeenCalledWith('list-1');
+    expect(usersResult.structuredContent).toEqual(users);
+    expect(invitationResult.structuredContent).toEqual(invitations);
+  });
 
-    it('should return error if usersettings structure is invalid', async () => {
-      const fakeSettingsInvalidStructure = { someOtherProperty: 'value' }; // Missing usersettings array
-      mockGetUserSettings.mockResolvedValue(fakeSettingsInvalidStructure);
-      mockLoadLists.mockResolvedValue({ lists: [] });
-      const tool = getTool('getDefaultList');
-      if (!tool) throw new Error('Tool getDefaultList not found');
-
-      const result = await tool.callback({});
-      expect(mockGetUserSettings).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({
-        content: [
-          {
-            type: 'text',
-            text: 'No default list is configured. Set one in the Bring app, or call loadLists to choose.',
-          },
-        ],
-        structuredContent: {
-          result: 'No default list is configured. Set one in the Bring app, or call loadLists to choose.',
+  it('normalizes both global and per-list setting keys', async () => {
+    mockGetUserSettings.mockResolvedValue({
+      userSettings: [{ key: 'defaultListUUID', value: 'list-1' }],
+      userlistsettings: [
+        {
+          listUuid: 'list-1',
+          usersettings: [{ key: 'notifications', value: 'true' }],
         },
-      });
+      ],
     });
 
-    it('should fall back to the sole list UUID when defaultListUUID is unset', async () => {
-      const soleListUuid = 'casa-list-uuid-456';
-      mockGetUserSettings.mockResolvedValue({
-        usersettings: [
-          { key: 'autoPush', value: 'true' },
-          { key: 'onboardClient', value: 'web' },
-        ],
-      });
-      mockLoadLists.mockResolvedValue({
-        lists: [{ listUuid: soleListUuid, name: 'Casa' }],
-      });
-      const tool = getTool('getDefaultList');
-      if (!tool) throw new Error('Tool getDefaultList not found');
+    const result = await getTool('getUserSettings')!.callback({});
 
-      const result = await tool.callback({});
-      expect(mockGetUserSettings).toHaveBeenCalledTimes(1);
-      expect(mockLoadLists).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({
-        content: [{ type: 'text', text: soleListUuid }],
-        structuredContent: { result: soleListUuid },
-      });
+    expect(result.structuredContent).toEqual({
+      settings: [{ key: 'defaultListUUID', value: 'list-1' }],
+      listSettings: [
+        {
+          listUuid: 'list-1',
+          settings: [{ key: 'notifications', value: 'true' }],
+        },
+      ],
+    });
+  });
+
+  it('returns the configured default list as a structured result', async () => {
+    mockGetUserSettings.mockResolvedValue({
+      usersettings: [{ key: 'defaultListUUID', value: 'configured-list' }],
     });
 
-    it('should return guidance when defaultListUUID is unset and multiple lists exist', async () => {
-      mockGetUserSettings.mockResolvedValue({
-        usersettings: [{ key: 'autoPush', value: 'true' }],
-      });
-      mockLoadLists.mockResolvedValue({
-        lists: [
-          { listUuid: 'uuid-a', name: 'Casa' },
-          { listUuid: 'uuid-b', name: 'Work' },
-        ],
-      });
-      const tool = getTool('getDefaultList');
-      if (!tool) throw new Error('Tool getDefaultList not found');
+    const result = await getTool('getDefaultList')!.callback({});
 
-      const result = await tool.callback({});
-      expect(mockLoadLists).toHaveBeenCalledTimes(1);
-      expect(result.content[0].text).toMatch(/loadLists/i);
-      expect(result.content[0].text).not.toMatch(/Failed to get default list UUID/i);
+    expect(result.structuredContent).toEqual({ listUuid: 'configured-list', source: 'configured' });
+    expect(mockLoadLists).not.toHaveBeenCalled();
+  });
+
+  it('uses the sole list if no default is configured', async () => {
+    mockGetUserSettings.mockResolvedValue({ userSettings: [] });
+    mockLoadLists.mockResolvedValue({
+      lists: [{ listUuid: 'only-list', name: 'Home', theme: 'ch.publisheria.bring.theme.1' }],
     });
 
-    it('should return guidance when defaultListUUID is unset and no lists exist', async () => {
-      mockGetUserSettings.mockResolvedValue({
-        usersettings: [{ key: 'autoPush', value: 'true' }],
-      });
-      mockLoadLists.mockResolvedValue({ lists: [] });
-      const tool = getTool('getDefaultList');
-      if (!tool) throw new Error('Tool getDefaultList not found');
+    const result = await getTool('getDefaultList')!.callback({});
 
-      const result = await tool.callback({});
-      expect(mockLoadLists).toHaveBeenCalledTimes(1);
-      expect(result.content[0].text).toMatch(/loadLists/i);
-      expect(result.content[0].text).not.toMatch(/Failed to get default list UUID/i);
+    expect(result.structuredContent).toEqual({ listUuid: 'only-list', source: 'only-list' });
+  });
+
+  it('returns actionable guidance if a list must be selected', async () => {
+    mockGetUserSettings.mockResolvedValue({ userSettings: [] });
+    mockLoadLists.mockResolvedValue({
+      lists: [
+        { listUuid: 'list-a', name: 'Home', theme: 'ch.publisheria.bring.theme.1' },
+        { listUuid: 'list-b', name: 'Work', theme: 'ch.publisheria.bring.theme.2' },
+      ],
+    });
+
+    const result = await getTool('getDefaultList')!.callback({});
+
+    expect(result.structuredContent).toEqual({
+      listUuid: null,
+      source: 'not-configured',
+      message: 'No default list is configured. Set one in the Bring app, or call loadLists to choose.',
+    });
+  });
+
+  it('marks user API failures as MCP errors', async () => {
+    mockGetUserSettings.mockRejectedValue(new Error('Settings unavailable'));
+
+    const result = await getTool('getDefaultList')!.callback({});
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Failed to get default list UUID: Settings unavailable' }],
+      isError: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- replace the monolithic MCP SDK v1 dependency with the split SDK v2 server package
- negotiate MCP 2026-07-28 while continuing to serve legacy 2025 clients over STDIO
- create a reusable server factory with package metadata, instructions, cache hints, and 16 fully described tools
- add concrete Zod input/output schemas, natural structured content, normalized mutation results, and isError tool failures
- add SDK v2 client protocol tests for modern and legacy wire projections

## Verification
- npm run test (57 tests)
- npm run test:ci
- npm run build
- npm audit --omit=dev (0 vulnerabilities)
- built STDIO smoke test: legacy 2025-11-25 and modern 2026-07-28, 16 tools each
- live MCP 2026-07-28 test: added a temporary item to the default Bring list, observed it through getItems, removed it, and verified it was gone